### PR TITLE
Update facebook-ads.md

### DIFF
--- a/pages/docs/other-bits/cohort-syncs/facebook-ads.md
+++ b/pages/docs/other-bits/cohort-syncs/facebook-ads.md
@@ -67,9 +67,9 @@ The Mixpanel Cohort is available in the Audience list. Cohorts are exported to F
 
 ## Data Requirement
 
-Facebook uses email address to match users from the cohort with users from their system. If they do not have the email address, they will instead use a combination of phone number or first and last name.
+Facebook uses email addresses to match users from the cohort with users from their system. If they do not have an email address, they will instead use a combination of phone number or first and last name.
 
-In order to use this integration, you must set email as a user profile property. In addition to email address, Mixpanel will send a first name user profile property, a last name user profile property, a phone number user property, and the distinct id. 
+In order to use this integration, you must set $email as a user profile property. In addition to email address, Mixpanel will send a first name user profile property, a last name user profile property, a phone number user property, and the distinct id. 
 
 Facebook excludes cohort members from the audience if they are unable to match them with a user in their system. An inequality between the number of users in the Facebook audience and Mixpanel cohort indicates that Facebook was unable to find the user.
 


### PR DESCRIPTION
Update Data Requirement section to showcase that the $email profile property must be set in order for the integration to work.