### PR TITLE
Update docs with latest group profile history details

### DIFF
--- a/pages/docs/tracking-methods/warehouse-connectors.mdx
+++ b/pages/docs/tracking-methods/warehouse-connectors.mdx
@@ -324,6 +324,8 @@ Here’s an example table that illustrates what can be loaded as group profiles 
 
 Group Profile History value and setup is similar to the User Profile History section elaborated above
 
+Generally, group profile history values can only be used for queries within that same group. To power user-mode queries that use a group profile history property, the latest value of the ingested property will be used instead. Following ingestion, there may be a delay before the latest value will be available in queries.
+
 ### Lookup Tables
 
 A Lookup Table is useful for enriching Mixpanel properties (e.g. content, skus, currencies) with additional metadata. Learn more about Lookup Tables [here](/docs/data-structure/lookup-tables). Note the limits of lookup tables indicated [here](/docs/data-structure/lookup-tables#when-shouldnt--i-use-lookup-tables).


### PR DESCRIPTION
Updating docs for user-group queries - 

Group profile history syncs from the warehouse will now sync the latest version of these properties as standard group profile properties, so that they can be made available in user-mode queries.