### PR TITLE
Add Sprig survey tracking for feature flags page

### DIFF
--- a/hooks/useSprig.ts
+++ b/hooks/useSprig.ts
@@ -58,11 +58,11 @@ export const useSprig = () => {
     }
   }, [sprigEnvironmentId]);
 
-  // Track experimentation page visits
+  // Track page visits for specific documentation pages
   useEffect(() => {
     if (!sprigEnvironmentId || typeof window === 'undefined') return;
 
-    const trackExperimentView = () => {
+    const trackPageView = (eventName: string) => {
       const now = Date.now();
 
       // Prevent duplicate events within debounce period
@@ -76,7 +76,7 @@ export const useSprig = () => {
 
       try {
         lastEventTime = now;
-        window.Sprig('track', 'viewed_experimentation_docs');
+        window.Sprig('track', eventName);
       } catch (error) {
         console.error('Sprig track failed:', error);
       }
@@ -84,52 +84,17 @@ export const useSprig = () => {
 
     const handleRouteChange = (url: string) => {
       if (url.includes('/docs/experiments')) {
-        trackExperimentView();
+        trackPageView('viewed_experimentation_docs');
+      } else if (url.includes('/docs/featureflags')) {
+        trackPageView('viewed_featureflags_docs');
       }
     };
 
-    // Track if already on experimentation page
+    // Track if already on a tracked page
     if (router.asPath.includes('/docs/experiments')) {
-      trackExperimentView();
-    }
-
-    router.events.on('routeChangeComplete', handleRouteChange);
-    return () => router.events.off('routeChangeComplete', handleRouteChange);
-  }, [router, sprigEnvironmentId]);
-
-  // Track feature flags page visits
-  useEffect(() => {
-    if (!sprigEnvironmentId || typeof window === 'undefined') return;
-
-    const trackFeatureFlagView = () => {
-      const now = Date.now();
-
-      // Prevent duplicate events within debounce period
-      if (now - lastEventTime < EVENT_DEBOUNCE_MS) {
-        return;
-      }
-
-      if (!window.Sprig) {
-        return;
-      }
-
-      try {
-        lastEventTime = now;
-        window.Sprig('track', 'viewed_featureflags_docs');
-      } catch (error) {
-        console.error('Sprig track failed:', error);
-      }
-    };
-
-    const handleRouteChange = (url: string) => {
-      if (url.includes('/docs/featureflags')) {
-        trackFeatureFlagView();
-      }
-    };
-
-    // Track if already on feature flags page
-    if (router.asPath.includes('/docs/featureflags')) {
-      trackFeatureFlagView();
+      trackPageView('viewed_experimentation_docs');
+    } else if (router.asPath.includes('/docs/featureflags')) {
+      trackPageView('viewed_featureflags_docs');
     }
 
     router.events.on('routeChangeComplete', handleRouteChange);


### PR DESCRIPTION
## Summary
- Added Sprig tracking event `viewed_featureflags_docs` that triggers when users visit `/docs/featureflags`
- Follows the same pattern as existing experiments page tracking (`viewed_experimentation_docs`)
- Uses shared debouncing logic to prevent duplicate events within 1 second
- Includes proper error handling and null checks

## Implementation Details
- Event name: `viewed_featureflags_docs` (follows naming pattern of `viewed_experimentation_docs`)
- Triggers on: Initial page load and route changes to `/docs/featureflags`
- Location: `hooks/useSprig.ts:95-137`

## Testing
- ✅ Verified event fires correctly when visiting feature flags page
- ✅ TypeScript compilation passes with no errors
- ✅ No React hooks violations
- ✅ No hydration errors
- ✅ Existing experiments tracking still works correctly
- ✅ Debouncing works across both trackers

## Test Plan
- [x] Visit `/docs/featureflags` and verify `viewed_featureflags_docs` event fires in Sprig
- [x] Navigate between experiments and feature flags pages to verify both events fire correctly
- [x] Verify no duplicate events are sent within 1 second

🤖 Generated with [Claude Code](https://claude.com/claude-code)