### PR TITLE
chore(deps-npm): bump typescript from 5.9.2 to 5.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "postcss": "8.5.6",
         "tailwind-variants": "3.1.1",
         "tailwindcss": "3.4.14",
-        "typescript": "5.9.2",
+        "typescript": "5.9.3",
         "yaml": "2.8.1"
       },
       "engines": {
@@ -11264,9 +11264,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -19796,9 +19796,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="
     },
     "ufo": {
       "version": "1.5.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "postcss": "8.5.6",
     "tailwind-variants": "3.1.1",
     "tailwindcss": "3.4.14",
-    "typescript": "5.9.2",
+    "typescript": "5.9.3",
     "yaml": "2.8.1"
   }
 }


### PR DESCRIPTION
manual recreation of https://github.com/mixpanel/docs/pull/2189