### PR TITLE
Revise Autocapture implementation guidance

### DIFF
--- a/pages/docs/tracking-methods/autocapture.mdx
+++ b/pages/docs/tracking-methods/autocapture.mdx
@@ -55,7 +55,7 @@ Autocapture can coexist with more precise tracking — you can both enable Autoc
 If you subscribe to automatic SDK updates, please note that these updates will not change your Autocapture configuration.
 
 <Callout type="info">
-    If you are an existing customer, we do not recommend changes to your SDK implementation (including turning on Autocapture) without speaking to a member of the Mixpanel team.
+    Before permanently implementing Autocapture, we recommend thoroughly testing the feature in a sandbox project to evaluate its impact on your data consumption and confirm that it meets your use case.
 </Callout>
 
 Customers adding the Javascript SDK with a snippet that contains an enabled autocapture config will turn on autocapture. **If this config is not present in the snippet, Autocapture will not be enabled.** Our documentation on how to configure the Javascript SDK, including changing your Autocapture configuration, [can be found here](https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript).


### PR DESCRIPTION
Updated recommendation for implementing Autocapture to emphasize testing in a sandbox project before permanent implementation.