### PR TITLE
Clarify Metric view description in Retention Trends report

### DIFF
--- a/pages/docs/reports/retention.mdx
+++ b/pages/docs/reports/retention.mdx
@@ -363,4 +363,4 @@ In our sample data, this computes to:(500 * (1000 / 1500)) + (400 * (500 / 1500)
 
 ### What does the Metric view in the Retention Trends report show?
 
-The Metric view in the Retention Trends Report shows the ***overall value*** for the retention trend for that time period.  There is a `Cohortize` option under the `Advanced` menu that, when enabled will show the ***last complete bucket*** for that retention trend. Metric charts are often used to look at the most up-to-date data value, which in this case, would be the last / most recently completed cell. For days where there isn't yet a completed cell, Mixpanel uses the closest completed cell for that day.
+The Metric view in the Retention Trends Report shows the ***overall value*** for the retention trend for that time period.  There is a `Cohortize` option under the `Advanced` menu that, when enabled will show the ***weighted average bucket*** for that retention trend.


### PR DESCRIPTION
Updated the Metric view description in the Retention Trends report to clarify the use of the weighted average bucket.
See confirmation here https://mixpanel.slack.com/archives/C03717NTL4W/p1765905388695219 