### PR TITLE
Add guidance on changing experiment settings mid-experiment

### DIFF
--- a/pages/docs/experiments.mdx
+++ b/pages/docs/experiments.mdx
@@ -67,9 +67,17 @@ Enter either the sample size (the number of users to be exposed to the experimen
 
 Mixpanel has set default automatic configurations, seen below. If required, please modify them as needed for the experiment
 
-1. **Experiment Model type**: Sequential 
-2. **Confidence Threshold**: 95% 
+1. **Experiment Model type**: Sequential
+2. **Confidence Threshold**: 95%
 3. **Experiment Start Date**: Date of the first user exposed to the experiment
+
+### Changing Settings Mid-Experiment
+
+Mixpanel analyzes your experiment on the fly, so you can adjust settings at any time if needed. If you notice a configuration mistake - like selecting Frequentist when you meant Sequential - feel free to correct it, even if the experiment has been running for weeks.
+
+The one thing to avoid is changing settings because the current results aren't what you hoped for. If you adjust the confidence level, metrics, or duration in search of a significant result, you're more likely to find something that looks meaningful but is actually noise. When you roll out that change, it may not deliver the improvement you expected.
+
+If you want to test a different configuration, restart the experiment instead. This resets the data and ensures your analysis starts fresh.
 
 ## Monitor Your Experiment
 


### PR DESCRIPTION
- Added a new section explaining when it's okay to change experiment settings (fixing configuration mistakes) vs. when to avoid it (chasing significant results)
- Recommend restarting the experiment if you want to test a different configuration