### PR TITLE
Clarify group keys limit in group analytics documentation

### DIFF
--- a/pages/docs/data-structure/group-analytics/group-analytics-implementation.mdx
+++ b/pages/docs/data-structure/group-analytics/group-analytics-implementation.mdx
@@ -68,7 +68,7 @@ The group key(s) and their value should be present in every event you want assoc
 	</Tabs.Tab>
 </Tabs>
 
-Do note this is just a convenience function; for server-side libraries, or if there's no access to local storage, you can send the group key and value in every event tracked. Below you will see the same flow using python.
+Note this is just a convenience function; for server-side libraries, or if there's no access to local storage, you can send the group key and value in every event tracked. Below you will see the same flow using python.
 
 ```python
 mp.track('$device:anoymous_id', 'page_view',{'$device_id':'anoymous_id'})
@@ -83,8 +83,9 @@ An event can be attributed to multiple groups. The convenience functions cited a
 ```javascript Javascript
 mixpanel.track("Some Event", { company_id: ["company 1", "company 2", "company 3"] });
 ```
-
-Note that there is a limit of 300 group keys that the event will be attributed to. All group keys beyond that limit will be ignored.
+<Callout type="info">
+ Up to 300 group keys may be assigned to an event. Any additional groups beyond that number are ignored.
+</Callout>
 
 ## Updating Group Profiles
 

--- a/pages/docs/data-structure/group-analytics/group-analytics-implementation.mdx
+++ b/pages/docs/data-structure/group-analytics/group-analytics-implementation.mdx
@@ -84,6 +84,8 @@ An event can be attributed to multiple groups. The convenience functions cited a
 mixpanel.track("Some Event", { company_id: ["company 1", "company 2", "company 3"] });
 ```
 
+Note that there is a limit of 300 group keys that the event will be attributed to. All group keys beyond that limit will be ignored.
+
 ## Updating Group Profiles
 
 To create or update a [group profile](../group-analytics#group-profiles), similarly to user profile operations, at least one (1) profile property must be set. A set operation for a group profile that does not exist would create said profile, while it would update an existing profile.


### PR DESCRIPTION
Added note about the limit of 300 group keys for event attribution.