### PR TITLE
Fix link to Legacy MTU Billing troubleshooting board

### DIFF
--- a/pages/docs/pricing/legacy-mtu-billing.md
+++ b/pages/docs/pricing/legacy-mtu-billing.md
@@ -94,4 +94,4 @@ The main scenarios that usually increase the number of MTUs:
 - A marketing campaign (can lead to an increase in tracked users due to an influx of anonymous visitors).
 - An update that adds tracking to new parts of your product.
 
-To assist in analyzing potential sources of MTU spikes, create a copy of [this board](https://mixpanel.com/project/2195193/view/139237/app/boards#id=5762529) from our demo project into the main project contributing to MTU charges. Once you open the board linked above, you can click on the 3 dots menu located on the top right-hand corner to duplicate the board, then move the duplicated board into your project.  
+To assist in analyzing potential sources of MTU spikes, create a copy of [this board](https://mixpanel.com/project/3409416/view/3914056/app/boards#id=10860850) from our demo project into the main project contributing to MTU charges. Once you open the board linked above, you can click on the 3 dots menu located on the top right-hand corner to duplicate the board, then move the duplicated board into your project.  


### PR DESCRIPTION
Updates the link to the Legacy MTU Billing troubleshooting board. The previous link is now inaccessible to customers.