### PR TITLE
Add custom device ID documentation for Swift SDK

### DIFF
--- a/pages/docs/tracking-methods/sdks/swift.mdx
+++ b/pages/docs/tracking-methods/sdks/swift.mdx
@@ -245,6 +245,51 @@ Mixpanel.mainInstance().reset()
     If you want to use IFV(identifierForVendor) as the distinct_id, you can set `MIXPANEL_UNIQUE_DISTINCT_ID` in build settings `Active Compilation Conditions` on the Mixpanel framework target. The IFV will not change when you call `reset`, but will change upon app uninstalls/reinstalls.
 </Callout>
 
+### Custom Device ID Generation
+
+The Swift SDK provides a [`deviceIdProvider`](https://mixpanel.github.io/mixpanel-swift/Classes/MixpanelOptions.html) closure in `MixpanelOptions` for implementing custom device ID generation logic. This allows you to control where device IDs are stored and whether they persist across `.reset()` calls.
+
+<Callout type="warning">
+    Using a custom device ID provider is an architectural decision that should be made at project inception. Changing this after deployment can cause user identity management issues.
+</Callout>
+
+Configure the device ID provider using `MixpanelOptions` when initializing the SDK. If the provider returns `nil` or an empty string, the SDK will fall back to generating a default device ID (UUID or IDFV).
+
+**Example Usage**
+```swift Swift
+// create a device ID provider
+let options = MixpanelOptions(
+    token: "YOUR_PROJECT_TOKEN",
+    deviceIdProvider: {
+        return getYourCustomDeviceId()
+    }
+)
+
+let mixpanel = Mixpanel.initialize(options: options)
+```
+
+**Persistent vs Ephemeral IDs**
+
+Returning the same value each time the provider is called creates a persistent device ID that survives `.reset()` calls. Returning different values generates a new device ID on each reset.
+
+```swift Swift
+// persistent ID - survives reset() calls
+let options = MixpanelOptions(
+    token: "YOUR_PROJECT_TOKEN",
+    deviceIdProvider: {
+        return getStoredDeviceId() // returns same value every time
+    }
+)
+
+// ephemeral ID - changes on reset() calls
+let options = MixpanelOptions(
+    token: "YOUR_PROJECT_TOKEN",
+    deviceIdProvider: {
+        return generateNewDeviceId() // returns new value each time
+    }
+)
+```
+
 
 ## Storing User Profiles
 


### PR DESCRIPTION
This pull request adds new documentation to the Swift SDK integration guide describing how to use a custom device ID provider with Mixpanel. The update explains the architectural implications, configuration, and usage patterns for persistent and ephemeral device IDs.

**Device ID Customization:**

* Added a section on using the `deviceIdProvider` closure in `MixpanelOptions` to implement custom device ID logic, allowing developers to control device ID storage and persistence across `.reset()` calls.
* Included example code snippets demonstrating how to set up persistent and ephemeral device IDs via the provider.
* Added a warning callout about the risks of changing device ID logic after deployment, emphasizing the importance of architectural planning.