### PR TITLE
Add Databricks to Data Warehouse destinations list

### DIFF
--- a/pages/docs/data-pipelines.mdx
+++ b/pages/docs/data-pipelines.mdx
@@ -47,6 +47,7 @@ JSON Pipelines also facilitate data export into tables, creating schemas that ar
 For detailed setup guides per destination, see:
 
 - [BigQuery](/docs/data-pipelines/integrations/bigquery)
+- [Databricks](/docs/data-pipelines/integrations/databricks)
 - [Redshift Spectrum](/docs/data-pipelines/integrations/redshift-spectrum)
 - [Snowflake](/docs/data-pipelines/integrations/snowflake)
 


### PR DESCRIPTION
## Summary
- Adds Databricks to the Data Warehouse setup guides list in the Data Pipelines overview page
- The Databricks integration page already exists at `/docs/data-pipelines/integrations/databricks` but was missing from the destinations list

## Test plan
- [ ] Verify the Databricks link renders correctly on the Data Pipelines overview page
- [ ] Confirm the link navigates to the existing Databricks integration page

🤖 Generated with [Claude Code](https://claude.com/claude-code)