### PR TITLE
Extract backfill historical events into shared snippet

### DIFF
--- a/pages/docs/data-pipelines.mdx
+++ b/pages/docs/data-pipelines.mdx
@@ -1,4 +1,5 @@
 import { Callout, Steps } from 'nextra/components'
+import BackfillHistoricalEvents from './data-pipelines/_snippets/BackfillHistoricalEvents.mdx'
 
 # Data Pipelines Overview
 
@@ -75,6 +76,10 @@ After configuring your destination, initiate data export in **Integrations** pag
 ![create_pipeline3](/create_pipeline3.png)
 
 </Steps>
+
+## Backfill Historical Events
+
+<BackfillHistoricalEvents />
 
 ## FAQ
 

--- a/pages/docs/data-pipelines/_snippets/BackfillHistoricalEvents.mdx
+++ b/pages/docs/data-pipelines/_snippets/BackfillHistoricalEvents.mdx
@@ -1,0 +1,5 @@
+You can schedule an initial backfill when creating events pipeline to ensure that historical data is also exported to the destination.
+
+Use the `from_date` parameter to specify the date from which you want to export historical data. Note that the `from_date` must be no more than 6 months in the past.
+
+The completion time for a backfill depends on the number of days and the volume of data in the project. Larger backfills can take several weeks.

--- a/pages/docs/data-pipelines/_snippets/BackfillHistoricalEvents.mdx
+++ b/pages/docs/data-pipelines/_snippets/BackfillHistoricalEvents.mdx
@@ -1,5 +1,11 @@
+import { Callout } from 'nextra/components'
+
 You can schedule an initial backfill when creating events pipeline to ensure that historical data is also exported to the destination.
 
-Use the `from_date` parameter to specify the date from which you want to export historical data. Note that the `from_date` must be no more than 6 months in the past.
+Use the `from_date` parameter to specify the date from which you want to export historical data.
+
+<Callout type="warning">
+  The `from_date` must be no more than 6 months in the past.
+</Callout>
 
 The completion time for a backfill depends on the number of days and the volume of data in the project. Larger backfills can take several weeks.

--- a/pages/docs/data-pipelines/json-pipelines.mdx
+++ b/pages/docs/data-pipelines/json-pipelines.mdx
@@ -1,4 +1,5 @@
 import { Callout } from 'nextra/components'
+import BackfillHistoricalEvents from './_snippets/BackfillHistoricalEvents.mdx'
 
 # Json Pipelines
 
@@ -70,11 +71,7 @@ Event data can fall out of sync between Mixpanel's datastore and the export dest
 
 ## Backfill Historical Events
 
-You can schedule an initial backfill when creating events pipeline to ensure that historical data is also exported to the destination.
-
-Use the `from_date` parameter to specify the date from which you want to export historical data. Note that the `from_date` must be no more than 6 months in the past.
-
-The completion time for a backfill depends on the number of days and the volume of data in the project. Larger backfills can take several weeks.
+<BackfillHistoricalEvents />
 
 ## Export Frequency
 

--- a/pages/docs/data-pipelines/old-pipelines/schematized-export-pipeline.mdx
+++ b/pages/docs/data-pipelines/old-pipelines/schematized-export-pipeline.mdx
@@ -1,4 +1,5 @@
 import { Callout } from 'nextra/components'
+import BackfillHistoricalEvents from '../_snippets/BackfillHistoricalEvents.mdx'
 
 # Schematized Export Pipeline
 
@@ -40,11 +41,7 @@ In addition, customers are limited to 1 date-range based pipeline creation per 2
 
 #### Backfilling Historical Data
 
-You can schedule an initial backfill when creating a pipeline. This ensures that historical data is also exported to the data warehouse.
-
-Use the `from_date` parameter to specify the date you want to use to export historical data. Note that the `from_date` must be no more than 6 months in the past.
-
-The completion time for a backfill depends on the number of days and the amount of data in the project. Larger backfills can take up to multiple weeks.
+<BackfillHistoricalEvents />
 
 ## User Data Support
 


### PR DESCRIPTION
This PR extracts the "Backfill Historical Events" section into a shared MDX snippet under `_snippets/` so the same content can be displayed on both the data pipelines overview page and the JSON pipelines page without duplicating the text. The `_` prefix ensures Nextra excludes the snippet directory from navigation.