### PR TITLE
Improve Databricks warehouse connector documentation

### DIFF
--- a/pages/docs/tracking-methods/warehouse-connectors.mdx
+++ b/pages/docs/tracking-methods/warehouse-connectors.mdx
@@ -192,47 +192,62 @@ IP allowlists are [not supported](https://docs.cloud.google.com/vpc-service-cont
 
 Complete the following steps to get your Databricks connector up and running:
 
-1. Navigate to **Project Settings**, then select **Warehouse Sources**.
-2. Click on `+ Add Connection` and select **Databricks**.
-3. You should see a new page to create your databricks connector. In the first view, fill out the following fields before clicking  `Create Source`:
-    - **Server Hostname** - This is the hostname of your Databricks cluster. This can be found in your workspace URL, or by navigating to [JDBC/ODBC connection settings](https://docs.databricks.com/en/integrations/jdbc-odbc-bi.html#step)
-    - **Access Token** - This is the Personal access token used to authenticate with your Databricks cluster. Here are the instructions on [how to create an access token](https://docs.databricks.com/en/dev-tools/auth.html#databricks-personal-access-tokens-for-workspace-users)
-    - **Compute Type** - Select your preferred compute option. We recommend using all-purpose compute for development use cases and jobs compute for production use cases.
-        - **All-Purpose Compute** - Uses an existing Databricks cluster. This option has faster sync start times since the cluster may already be running, but can be more expensive as the cluster remains running after the sync completes until it times out.
-        - **Jobs Compute (Beta)** - Creates a dedicated Databricks job for each sync. You are only billed by Databricks for the exact duration of the job, making this more cost-effective. However, each sync has a longer start time (approximately 5-6 minutes) due to cluster spin-up. Also note that jobs compute does not support previewing data in the Mixpanel UI.
-    - **HTTP Path** - For all-purpose compute, this is the HTTP path of the cluster you would like to connect to. This can be found in your cluster [JDBC/ODBC connection settings](https://docs.databricks.com/en/integrations/jdbc-odbc-bi.html#step)
-4. In the second view, you should see that the credentials are validated and a source is added.
+### Step 1: Set up authentication
 
-### Using Service Principals
-If a service principal is used, you'll want to follow these steps:
-1. [Create the service principal](https://docs.databricks.com/en/admin/users-groups/service-principals.html#manage-service-principals-in-your-account) if it doesn't exist.
-2. Create a token for the service principal. You can do so through the Databricks CLI:
+You can authenticate with either a personal access token or a service principal. We recommend using a **service principal** for production use cases.
+
+**Option A: Personal Access Token**
+
+Create a personal access token by following the [Databricks instructions](https://docs.databricks.com/en/dev-tools/auth.html#databricks-personal-access-tokens-for-workspace-users). Save this token — you'll need it when connecting in Mixpanel.
+
+**Option B: Service Principal (Recommended)**
+
+1. [Create the service principal](https://docs.databricks.com/en/admin/users-groups/service-principals.html#manage-service-principals-in-your-account) in your Databricks account if it doesn't already exist.
+2. Generate a token for the service principal using the Databricks CLI:
 ```bash
 databricks configure --token
 databricks token-management create-obo-token <application_id_of_service_principal> --lifetime-seconds 31536000 --comment "Mixpanel warehouse connector service principal token"
 ```
-3. Copy the token generated for later use
-4. Give the service principal `Can Attach` permissions to the cluster (in Cluster > Permissions)
-    - Note the cluster needs to be a shared compute resource and not a single-user cluster (unless the service principal created the cluster as well)
-5. Give the service principal access to the catalogs you want to read in Mixpanel
-6. Grant the service principal file-level permissions. Mixpanel needs to read your table data and write results to cloud storage. Run the following SQL in your Databricks workspace:
+3. Save the generated token — you'll need it when connecting in Mixpanel.
+
+### Step 2: Grant permissions
+
+The user or service principal you're connecting with needs the following permissions. The exact permissions depend on which compute type you plan to use.
+
+**Compute permissions:**
+
+| Permission | All-Purpose Compute | Jobs Compute |
+|---|---|---|
+| `CAN ATTACH TO` on the cluster | Required | Not needed |
+| `CAN RESTART` on the cluster | Required if the cluster auto-suspends | Not needed |
+| Cluster creation permissions | Not needed | Required |
+
+For all-purpose compute, the cluster must be a **shared** compute resource, not a single-user cluster (unless the service principal created the cluster).
+
+You can set these in Databricks under **Compute → your cluster → Edit Permissions**.
+
+**Data permissions:**
+
+Grant read access to the catalogs and schemas you want to sync to Mixpanel. You can do this in Databricks under **Catalog → your catalog → Permissions → Grant**, and select the **Data Reader** role.
+
+Mixpanel also needs file-level permissions to read table data and write intermediate results to cloud storage. Run the following SQL in a Databricks notebook or SQL editor:
 ```sql
-GRANT SELECT ON ANY FILE TO `<application_id_of_service_principal>`;
-GRANT MODIFY ON ANY FILE TO `<application_id_of_service_principal>`;
+GRANT SELECT ON ANY FILE TO `<application_id_or_username>`;
+GRANT MODIFY ON ANY FILE TO `<application_id_or_username>`;
 ```
-7. During the setup process in Mixpanel, you can now use the token from the service principal when setting up the connection
 
-### Required Permissions
+### Step 3: Connect in Mixpanel
 
-The account or service principal used for the connection requires different permissions depending on the compute type selected:
-
-- **All-Purpose Compute**:
-  - `CAN ATTACH TO` permission on the cluster
-  - `CAN RESTART` permission on the cluster (if the cluster auto-suspends)
-  - `CAN USE` permission on the SQL warehouse the cluster leverages
-
-- **Jobs Compute**:
-  - Cluster creation permissions - the account or service principal needs permission to create job clusters
+1. Navigate to **Project Settings**, then select **Warehouse Sources**.
+2. Click on `+ Add Connection` and select **Databricks**.
+3. Fill out the following fields, then click **Create Source**:
+    - **Server Hostname** — The hostname of your Databricks workspace. Find this in your workspace URL, or under your cluster's [JDBC/ODBC settings](https://docs.databricks.com/en/integrations/jdbc-odbc-bi.html#step).
+    - **Access Token** — The personal access token or service principal token you created above.
+    - **Compute Type** — Select your preferred compute option:
+        - **All-Purpose Compute** — Uses an existing cluster. Faster sync start times, but the cluster stays running after the sync completes until it times out. Best for development.
+        - **Jobs Compute (Beta)** — Creates a dedicated job for each sync. You're only billed for the exact job duration, making it more cost-effective. Syncs take ~5-6 minutes longer to start due to cluster spin-up, and data preview in the Mixpanel UI is not supported. Best for production.
+    - **HTTP Path** — For all-purpose compute, the HTTP path of your cluster. Find this under your cluster's [JDBC/ODBC settings](https://docs.databricks.com/en/integrations/jdbc-odbc-bi.html#step).
+4. Confirm that the credentials are validated and the source is added.
 
 
 ### IP Allowlist

--- a/pages/docs/tracking-methods/warehouse-connectors.mdx
+++ b/pages/docs/tracking-methods/warehouse-connectors.mdx
@@ -209,16 +209,16 @@ If a service principal is used, you'll want to follow these steps:
 2. Create a token for the service principal. You can do so through the Databricks CLI:
 ```bash
 databricks configure --token
-databricks token-management create-obo-token <application_id_of_service_principal> 31536000 --comment "Mixpanel warehouse connector service principal token"
+databricks token-management create-obo-token <application_id_of_service_principal> --lifetime-seconds 31536000 --comment "Mixpanel warehouse connector service principal token"
 ```
 3. Copy the token generated for later use
 4. Give the service principal `Can Attach` permissions to the cluster (in Cluster > Permissions)
     - Note the cluster needs to be a shared compute resource and not a single-user cluster (unless the service principal created the cluster as well)
 5. Give the service principal access to the catalogs you want to read in Mixpanel
-6. When table access control is enabled in the account, the service principal also requires access to the files that will be read. You can add access like:
-```bash
-GRANT SELECT ON ANY FILE TO <application_id_of_service_principal>
-GRANT MODIFY ON ANY FILE TO <application_id_of_service_principal>
+6. Grant the service principal file-level permissions. Mixpanel needs to read your table data and write results to cloud storage. Run the following SQL in your Databricks workspace:
+```sql
+GRANT SELECT ON ANY FILE TO `<application_id_of_service_principal>`;
+GRANT MODIFY ON ANY FILE TO `<application_id_of_service_principal>`;
 ```
 7. During the setup process in Mixpanel, you can now use the token from the service principal when setting up the connection
 

--- a/pages/docs/tracking-methods/warehouse-connectors.mdx
+++ b/pages/docs/tracking-methods/warehouse-connectors.mdx
@@ -198,7 +198,7 @@ You can authenticate with either a personal access token or a service principal.
 
 **Option A: Personal Access Token**
 
-Create a personal access token by following the [Databricks instructions](https://docs.databricks.com/en/dev-tools/auth.html#databricks-personal-access-tokens-for-workspace-users). Save this token — you'll need it when connecting in Mixpanel.
+Create a personal access token by following the [Databricks instructions](https://docs.databricks.com/aws/en/dev-tools/auth/pat#create-personal-access-tokens-for-workspace-users). Save this token — you'll need it when connecting in Mixpanel.
 
 **Option B: Service Principal (Recommended)**
 


### PR DESCRIPTION
Previous Databricks documentation was confusing — steps were scattered between "using service principal" and "required permissions" 