### PR TITLE
[Docs] Move Postgres Connector from Public Beta to GA

### DIFF
--- a/pages/changelogs/2026-04-10-postgres-connector-ga.mdx
+++ b/pages/changelogs/2026-04-10-postgres-connector-ga.mdx
@@ -1,0 +1,29 @@
+---
+title: "Postgres Connector is now Generally Available"
+slug: "changelog-2026-04-10-postgres-connector-ga"
+hidden: false
+createdAt: "2026-04-10T00:00:00.000Z"
+updatedAt: "2026-04-10T00:00:00.000Z"
+date: "2026-04-10"
+description: "The Postgres Connector is now Generally Available — connect your Postgres database directly to Mixpanel to get started."
+isAnnouncement: false
+---
+
+<ChangelogPostHeader
+  date="2026-04-10"
+  title="Postgres Connector is now Generally Available"
+/>
+
+The **Postgres Connector** is now **Generally Available**.
+
+Since launching in Public Beta earlier this year, we've worked closely with early users to refine reliability, performance, and setup experience. It's ready for production.
+
+### What you can do with it
+
+Connect your Postgres database directly to Mixpanel and start analyzing your transactional data alongside your product usage — no ETL pipelines, no CDPs, no custom scripts required.
+
+This is especially useful if your most important data (user records, subscription state, AI model logs) lives in a transactional database and hasn't been making it into your analytics. The Postgres Connector closes that gap with minimal setup.
+
+Works with all major managed Postgres providers, including Amazon RDS, Google Cloud SQL, Supabase, Neon, and DigitalOcean Managed PostgreSQL.
+
+Get started with the [Postgres Connector](/docs/tracking-methods/warehouse-connectors).

--- a/pages/docs/tracking-methods/warehouse-connectors.mdx
+++ b/pages/docs/tracking-methods/warehouse-connectors.mdx
@@ -404,10 +404,6 @@ If you are using [AWS PrivateLink](https://docs.aws.amazon.com/redshift/latest/m
 </Tabs.Tab>
 <Tabs.Tab>
 
-<Callout type="info">
-The Postgres connector is currently in beta.
-</Callout>
-
 Complete the following steps to get your Postgres connector up and running:
 
 1. Navigate to **Project Settings**, then select **Warehouse Sources**.


### PR DESCRIPTION
- Remove beta callout banner from warehouse connectors docs
- Add changelog post announcing Postgres Connector is now Generally Available