### PR TITLE
[TOF-196] Keep email subscription on Changelog page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode

--- a/changelogs.mdx
+++ b/changelogs.mdx
@@ -2,6 +2,7 @@
 title: Changelogs
 ---
 
+import { SubscribeButtonWithModal } from "/snippets/SubscribeButtonWithModal/SubscribeButtonWithModal.jsx";
 import Update20260515DatabricksPipelineGa from "/snippets/changelogs/2026-05-15-databricks-pipeline-ga.mdx";
 import Update20260429StripeProjects from "/snippets/changelogs/2026-04-29-stripe-projects.mdx";
 import Update20260414CustomRoles from "/snippets/changelogs/2026-04-14-custom-roles.mdx";
@@ -144,6 +145,10 @@ import Update20220531ImproveConversionFlow from "/snippets/changelogs/2022-05-31
 import Update20220524LexiconContext from "/snippets/changelogs/2022-05-24-lexicon-context.mdx";
 import Update20220418RelativeComparison from "/snippets/changelogs/2022-04-18-relative-comparison.mdx";
 import Update20220329TextBoards from "/snippets/changelogs/2022-03-29-text-boards.mdx";
+
+Get all the latest updates in your inbox.
+
+<SubscribeButtonWithModal />
 
 <Update20260515DatabricksPipelineGa/>
 

--- a/snippets/SubscribeButtonWithModal/SubscribeButtonWithModal.jsx
+++ b/snippets/SubscribeButtonWithModal/SubscribeButtonWithModal.jsx
@@ -13,7 +13,8 @@ export const SubscribeButtonWithModal = () => {
   const [error, setError] = useState("");
   const [inputState, setInputState] = useState(STATE.DEFAULT);
 
-  const submitDisabled = inputState === STATE.ERROR || !agreedToTerms;
+  const submitDisabled =
+    inputState === STATE.ERROR || inputState === STATE.SUCCESS || !agreedToTerms;
 
   const openModal = () => dialogRef.current?.showModal?.();
   const closeModal = () => dialogRef.current?.close?.();

--- a/snippets/SubscribeButtonWithModal/SubscribeButtonWithModal.jsx
+++ b/snippets/SubscribeButtonWithModal/SubscribeButtonWithModal.jsx
@@ -6,16 +6,17 @@ export const SubscribeButtonWithModal = () => {
 
   const STATE = { DEFAULT: "default", FOCUS: "focus", ERROR: "error", SUCCESS: "success" };
 
-  const BUTTON_CLASS =
-    "px-5 py-3 my-4 drop-shadow-sm bg-gradient-to-t from-[#7856ff] to-[#9b7eff] rounded-full text-white font-medium";
+  const dialogRef = useRef(null);
 
   const [email, setEmail] = useState("");
   const [agreedToTerms, setAgreedToTerms] = useState(false);
   const [error, setError] = useState("");
-  const [isOpen, setIsOpen] = useState(false);
   const [inputState, setInputState] = useState(STATE.DEFAULT);
 
   const submitDisabled = inputState === STATE.ERROR || !agreedToTerms;
+
+  const openModal = () => dialogRef.current?.showModal?.();
+  const closeModal = () => dialogRef.current?.close?.();
 
   const validateEmail = () => {
     if (!email) {
@@ -61,68 +62,71 @@ export const SubscribeButtonWithModal = () => {
 
   return (
     <div>
-      <button type="button" onClick={() => setIsOpen(true)} className={BUTTON_CLASS}>
+      <button
+        type="button"
+        onClick={openModal}
+        className="px-5 py-3 my-4 drop-shadow-sm bg-gradient-to-t from-[#7856ff] to-[#9075ff] rounded-full text-white font-medium"
+      >
         Subscribe
       </button>
 
-      {isOpen && (
-        <div
-          className="fixed inset-0 flex w-screen items-center justify-center p-4 bg-black/80 z-50"
-          onClick={() => setIsOpen(false)}
-        >
-          <div className="w-full max-w-2xl" onClick={(e) => e.stopPropagation()}>
-            <div className="changelogSubscribeModalInner bg-white dark:bg-gray-900 p-8 rounded-3xl">
-              <div className="text-3xl font-medium text-center mb-4">Subscribe to product updates</div>
-              <div className="text-lg text-center mb-6">Sign up to stay up-to-date on our newest releases.</div>
+      <dialog
+        ref={dialogRef}
+        onClick={(e) => {
+          if (e.target === dialogRef.current) closeModal();
+        }}
+        className="w-full max-w-2xl p-0 rounded-3xl bg-transparent backdrop:bg-black/80"
+      >
+        <div className="bg-[#fbf9f9] dark:bg-[#201f24] p-8 rounded-3xl">
+          <div className="text-3xl font-medium text-center mb-4">Subscribe to product updates</div>
+          <div className="text-lg text-center mb-6">Sign up to stay up-to-date on our newest releases.</div>
 
-              <div className="flex flex-col">
-                <label className="font-medium ml-6 mb-1">Company Email</label>
-                <input
-                  className="rounded-full px-6 py-3.5 outline-[#7856ff] border border-gray-200"
-                  aria-label="Email address"
-                  disabled={inputState === STATE.SUCCESS}
-                  value={inputState === STATE.SUCCESS ? "Thanks for subscribing!" : email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  placeholder="you@email.com"
-                  onFocus={() => setInputState(STATE.FOCUS)}
-                  onBlur={() => {
-                    setInputState(STATE.DEFAULT);
-                    validateEmail();
-                  }}
-                />
-              </div>
-
-              {error && <p className="text-xs text-red-600 ml-6 mt-1">{error}</p>}
-
-              <div className="flex mt-4">
-                <input
-                  className="mr-2"
-                  type="checkbox"
-                  aria-label="Agree to terms"
-                  disabled={inputState === STATE.SUCCESS}
-                  onChange={() => setAgreedToTerms((v) => !v)}
-                  onBlur={validateEmail}
-                />
-                <span className="text-gray-500 text-xs leading-normal">
-                  I agree to receive product update emails about Mixpanel products pursuant to the{" "}
-                  <a href="https://www.mixpanel.com/legal/privacy-policy" target="_blank" rel="noreferrer">
-                    Privacy Statement
-                  </a>
-                  . I understand that I can opt-out at any time.
-                </span>
-              </div>
-
-              <button
-                onClick={handleSubmit}
-                disabled={submitDisabled}
-                className={`${BUTTON_CLASS} disabled:opacity-50 disabled:cursor-not-allowed`}
-              >
-                Subscribe
-              </button>
-            </div>
+          <div className="flex flex-col">
+            <label className="font-medium ml-6 mb-1">Company Email</label>
+            <input
+              className="rounded-full px-6 py-3.5 outline-[#7856ff]"
+              aria-label="Email address"
+              disabled={inputState === STATE.SUCCESS}
+              value={inputState === STATE.SUCCESS ? "Thanks for subscribing!" : email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@email.com"
+              onFocus={() => setInputState(STATE.FOCUS)}
+              onBlur={() => {
+                setInputState(STATE.DEFAULT);
+                validateEmail();
+              }}
+            />
           </div>
+
+          {error && <p className="text-xs text-[#cc332b] ml-6 mt-1">{error}</p>}
+
+          <div className="flex items-start gap-3 mt-4">
+            <input
+              className="mt-1 flex-shrink-0"
+              type="checkbox"
+              aria-label="Agree to terms"
+              disabled={inputState === STATE.SUCCESS}
+              checked={agreedToTerms}
+              onChange={() => setAgreedToTerms((v) => !v)}
+            />
+            <span className="text-[#626266] text-xs leading-normal">
+              I agree to receive product update emails about Mixpanel products pursuant to the{" "}
+              <a href="https://www.mixpanel.com/legal/privacy-policy" target="_blank" rel="noreferrer">
+                Privacy Statement
+              </a>
+              . I understand that I can opt-out at any time.
+            </span>
+          </div>
+
+          <button
+            onClick={handleSubmit}
+            disabled={submitDisabled}
+            className="px-5 py-3 my-4 drop-shadow-sm bg-gradient-to-t from-[#7856ff] to-[#9075ff] rounded-full text-white font-medium"
+          >
+            Subscribe
+          </button>
         </div>
-      )}
+      </dialog>
     </div>
   );
 };

--- a/snippets/SubscribeButtonWithModal/SubscribeButtonWithModal.jsx
+++ b/snippets/SubscribeButtonWithModal/SubscribeButtonWithModal.jsx
@@ -76,7 +76,7 @@ export const SubscribeButtonWithModal = () => {
 
       <dialog
         ref={dialogRef}
-        onClick={(e) => {
+        onMouseDown={(e) => {
           if (e.target === dialogRef.current) closeModal();
         }}
         className="w-full max-w-2xl p-0 rounded-3xl bg-transparent backdrop:bg-black/80"

--- a/snippets/SubscribeButtonWithModal/SubscribeButtonWithModal.jsx
+++ b/snippets/SubscribeButtonWithModal/SubscribeButtonWithModal.jsx
@@ -14,7 +14,10 @@ export const SubscribeButtonWithModal = () => {
   const [inputState, setInputState] = useState(STATE.DEFAULT);
 
   const submitDisabled =
-    inputState === STATE.ERROR || inputState === STATE.SUCCESS || !agreedToTerms;
+    !agreedToTerms ||
+    inputState === STATE.SUCCESS ||
+    !email ||
+    !EMAIL_REGEX.test(email);
 
   const openModal = () => dialogRef.current?.showModal?.();
   const closeModal = () => dialogRef.current?.close?.();
@@ -101,9 +104,9 @@ export const SubscribeButtonWithModal = () => {
 
           {error && <p className="text-xs text-[#cc332b] ml-6 mt-1">{error}</p>}
 
-          <div className="flex items-start gap-3 mt-4">
+          <div className="flex items-center gap-3 mt-4">
             <input
-              className="mt-1 flex-shrink-0"
+              className="flex-shrink-0"
               type="checkbox"
               aria-label="Agree to terms"
               disabled={inputState === STATE.SUCCESS}
@@ -122,7 +125,7 @@ export const SubscribeButtonWithModal = () => {
           <button
             onClick={handleSubmit}
             disabled={submitDisabled}
-            className="px-5 py-3 my-4 drop-shadow-sm bg-gradient-to-t from-[#7856ff] to-[#9075ff] rounded-full text-white font-medium"
+            className="px-5 py-3 my-4 drop-shadow-sm bg-gradient-to-t from-[#7856ff] to-[#9075ff] rounded-full text-white font-medium disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Subscribe
           </button>


### PR DESCRIPTION
Wires the existing SubscribeButtonWithModal into the migrated Mintlify changelog page, switches the modal to a native `<dialog>` (top-layer rendering blocks background interaction), and aligns colors/spacing with the legacy Mixpanel design tokens.

Linear link: https://linear.app/mixpanel/issue/TOF-196/

# Test / Rollout plan
https://www.loom.com/share/33b77eff97dc4fce99084bfde60ab992



> **End-to-end (POST + tracking) cannot be verified until cutover.** The backend at `/api/app/form/gtm_form` (`analytics/webapp/app_api/form/views.py:88-95`) rejects requests whose `Origin` header doesn't contain `mixpanel.com`/`mixpanel.org` with `400`. Until the Mintlify-rendered docs are served from `docs.mixpanel.com`, the API call returns 400. UI/validation/modal behavior can still be fully validated locally and on the Mintlify staging preview.

- Run `mintlify dev` from the repo root and open `/changelogs`. Confirm the "Get all the latest updates in your inbox." caption and purple Subscribe button render above the changelog list.
- Click Subscribe → modal opens centered, dim backdrop covers the page, the changelog dates in the background are NOT clickable, and ESC closes the modal.
- Submit with empty email → "Email address is required." in red, button stays disabled. Submit invalid format (e.g. `fdsfds`) → "Please enter a valid email address", button stays disabled even after re-focusing the field. Ticking the consent box alone (without a valid email) does NOT enable the button.
- Toggle to dark mode and re-verify.
- (after cutover) In DevTools → Network, confirm `POST https://mixpanel.com/api/app/form/gtm_form` returns 200 with the email in the JSON body. In Console, confirm `[DOCS] Subscribed to Product Updates` fired via `window.mixpanel.track`.
- Spot-check with a real email and confirm the entry lands in the downstream email system (same endpoint + payload shape as the legacy docs subscribe button).

**Rollback**: revert this PR.