### PR TITLE
[TOF-204] Add Sentry error monitoring via loader script

### DIFF
--- a/scripts/sentry.js
+++ b/scripts/sentry.js
@@ -16,6 +16,7 @@
       replaysSessionSampleRate: 0,
       // Generic network noise (failed/cancelled fetches, offline) that adds no signal.
       ignoreErrors: ["Failed to fetch", "Load failed"],
+      allowUrls: [/docs\.mixpanel\.com/, /mintlify\.app/],
     });
   };
 

--- a/scripts/sentry.js
+++ b/scripts/sentry.js
@@ -14,11 +14,8 @@
     Sentry.init({
       // disables session replay by default
       replaysSessionSampleRate: 0,
-      ignoreErrors: [
-        // Qualified SDK (js.qualified.com) rejects promises with the raw string
-        // "unauthorized" for unauthenticated visitors. See TOF-113.
-        "Non-Error promise rejection captured with value: unauthorized",
-      ],
+      // Generic network noise (failed/cancelled fetches, offline) that adds no signal.
+      ignoreErrors: ["Failed to fetch", "Load failed"],
     });
   };
 

--- a/scripts/sentry.js
+++ b/scripts/sentry.js
@@ -1,0 +1,27 @@
+// We use Sentry's Loader Script, which lazy-loads the full SDK from the CDN and
+// calls window.sentryOnLoad (defined first) to run Sentry.init.
+
+// Wrapped in an IIFE to keep its top-level variables out of the shared global
+// scope Mintlify uses for all custom JS files.
+(function () {
+  const SENTRY_LOADER_SRC =
+    "https://js.sentry-cdn.com/6200201fbaac39435129c90af2fc30cb.min.js"; // docs project
+
+  // Configure sentryOnLoad before adding the Loader Script.
+  window.sentryOnLoad = function () {
+    Sentry.init({
+      // disables session replay by default
+      replaysSessionSampleRate: 0,
+      ignoreErrors: [
+        // Qualified SDK (js.qualified.com) rejects promises with the raw string
+        // "unauthorized" for unauthenticated visitors. See TOF-113.
+        "Non-Error promise rejection captured with value: unauthorized",
+      ],
+    });
+  };
+
+  const loader = document.createElement("script");
+  loader.src = SENTRY_LOADER_SRC;
+  loader.crossOrigin = "anonymous";
+  document.head.appendChild(loader);
+})();

--- a/scripts/sentry.js
+++ b/scripts/sentry.js
@@ -9,6 +9,8 @@
 
   // Configure sentryOnLoad before adding the Loader Script.
   window.sentryOnLoad = function () {
+    // The loader calls this once; remove it so it doesn't linger on the global scope.
+    delete window.sentryOnLoad;
     Sentry.init({
       // disables session replay by default
       replaysSessionSampleRate: 0,

--- a/scripts/sentry.js
+++ b/scripts/sentry.js
@@ -16,7 +16,10 @@
       replaysSessionSampleRate: 0,
       // Generic network noise (failed/cancelled fetches, offline) that adds no signal.
       ignoreErrors: ["Failed to fetch", "Load failed"],
-      allowUrls: [/docs\.mixpanel\.com/, /mintlify\.app/],
+      allowUrls: [
+        /^https:\/\/docs\.mixpanel\.com\//,
+        /^https:\/\/[\w.-]+\.mintlify\.app\//,
+      ],
     });
   };
 


### PR DESCRIPTION
Adds Sentry error monitoring to the Mintlify docs site. Mintlify has no npm/bundler entry point for custom code, so this uses Sentry's lazy CDN **Loader Script** delivered through Mintlify's custom-JS mechanism (any `.js` in the content directory is auto-included on every page).

- New `scripts/sentry.js`: defines `window.sentryOnLoad` then appends the loader for the docs project.
- Wrapped in an IIFE so its top-level vars stay out of the global scope Mintlify shares across custom JS files.

Linear link: https://linear.app/mixpanel/issue/TOF-204/

Example sentries:
https://mixpanel.sentry.io/issues/7542469799/?project=4509680694984704&query=&referrer=issue-stream
https://mixpanel.sentry.io/issues/7542635014/?project=4509680694984704&query=&referrer=issue-stream

# Test / Rollout plan
- Run `mintlify dev` at the repo root (or open this PR's Mintlify staging link).
- In DevTools **Network**: confirm a 200 request to `js.sentry-cdn.com/6200201fbaac39435129c90af2fc30cb.min.js`.
- In DevTools **Console**: confirm `window.Sentry` is defined, then run `Sentry.captureMessage("TOF-204 test")`.
- In the Sentry **docs** project (org `o81318`, project `4509680694984704`): confirm the test event arrives.
- Rollback: revert this commit (removes `scripts/sentry.js`); Sentry stops loading on next deploy.