### PR TITLE
Add Mixpanel analytics integration to docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -10,6 +10,9 @@
   "integrations": {
     "gtm": {
       "tagId": "GTM-MRDR9SP"
+    },
+    "mixpanel": {
+      "projectToken": "metrics-1"
     }
   },
   "background": {


### PR DESCRIPTION
Enable Mintlify's native Mixpanel integration in `docs.json` so docs site traffic is tracked in Mixpanel alongside the existing GTM tag.

- Add `integrations.mixpanel.projectToken` to `docs.json`

Linear link: https://linear.app/mixpanel/issue/TOF-247/

# Test / Rollout plan
Mintlify preview: https://mixpanel-edb78807-tof-247-mixpanel-integration.mintlify.app/

Example events: https://mixpanel.com/project/3/view/75/app/events#SuS4JUVo6PxX

<img width="1012" height="826" alt="image" src="https://github.com/user-attachments/assets/a9595ed4-f911-4c9b-867c-013b1629cc68" />




- After deploy, open the docs site and confirm `mixpanel-js` loads and `api.mixpanel.com/track` requests fire on page navigation (browser DevTools → Network).
- Confirm pageview events arrive in the corresponding Mixpanel project.
- Verify the existing GTM tag (`GTM-MRDR9SP`) still loads and is unaffected.
- Rollback: revert this commit to remove the `mixpanel` integration block.