### PR TITLE
[TOF-201] Fix broken redirects in docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1600,8 +1600,8 @@
       "destination": "/docs/admin/organizations-projects"
     },
     {
-      "source": "/:zendesk_attachmentattachments/token/:path*",
-      "destination": "https://mixpanelsupport.zendesk.com/:zendesk_attachment"
+      "source": "/attachments/token/:path*",
+      "destination": "https://mixpanelsupport.zendesk.com/attachments/token/:path*"
     },
     {
       "source": "/hc/articles/360000679006/:path*",

--- a/docs.json
+++ b/docs.json
@@ -2897,15 +2897,15 @@
     },
     {
       "source": "/docs/data-pipelines/integrations/azure-raw-pipeline",
-      "destination": "/docs/data-pipelines/integrations/raw-azure-pipeline"
+      "destination": "/docs/data-pipelines/old-pipelines/integrations/raw-azure-pipeline"
     },
     {
       "source": "/docs/data-pipelines/integrations/google-cloud-storage",
-      "destination": "/docs/data-pipelines/integrations/schematized-gcs-pipeline"
+      "destination": "/docs/data-pipelines/old-pipelines/integrations/schematized-gcs-pipeline"
     },
     {
       "source": "/docs/data-pipelines/integrations/google-cloud-storage-raw-pipeline",
-      "destination": "/docs/data-pipelines/integrations/raw-gcs-pipeline"
+      "destination": "/docs/data-pipelines/old-pipelines/integrations/raw-gcs-pipeline"
     },
     {
       "source": "/docs/data-pipelines/integrations/raw-aws-pipeline",

--- a/docs.json
+++ b/docs.json
@@ -1272,6 +1272,10 @@
   },
   "redirects": [
     {
+      "source": "/changelogs/*",
+      "destination": "/changelogs"
+    },
+    {
       "source": "/developer-docs-redirect/android",
       "destination": "/docs/tracking-methods/sdks/android"
     },


### PR DESCRIPTION
Fixes redirect issues in `docs.json`:

- **Zendesk attachments:** corrects the malformed param syntax so help-center attachment links forward to Zendesk with the full path preserved.
- **Data-pipeline redirects:** repoints three `/docs/data-pipelines/integrations/*` redirects (`azure-raw-pipeline`, `gcs`, `gcs-raw-pipeline`) to their real pages under `old-pipelines/`, which were previously chaining to 404s.
- **Changelogs:** adds `/changelogs/* → /changelogs`, since Mintlify serves the changelog as a single page (no per-article pages). Uses the glob form so the bare `/changelogs` page isn't matched (avoids a redirect loop).

Everything else from the source redirect files is already included in the redirect configuration in `docs.json` (note that we will forward traffic from `help.mixpanel.com` and `developer.mixpanel.com` to `docs.mixpanel.com` during cutover):
- https://github.com/mixpanel/docs/blob/main/redirects/help-mixpanel-com.txt
- https://github.com/mixpanel/docs/blob/main/redirects/developer-mixpanel-com.txt

Linear link: https://linear.app/mixpanel/issue/TOF-201/

# Test / Rollout plan
- After deploy, hit a sample of redirect source paths and confirm each 308-redirects to the expected destination and lands on a live page (no 404s), including the fixed Zendesk attachment, data-pipeline, and changelog redirects.
- Rollback: revert these commits.