### PR TITLE
[TOF-284] Set canonical URL in docs.json for SEO

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -52,6 +52,11 @@
     ]
   },
   "favicon": "/favicon.png",
+  "seo": {
+    "metatags": {
+      "canonical": "https://docs.mixpanel.com"
+    }
+  },
   "navigation": {
     "tabs": [
       {


### PR DESCRIPTION
Add a `seo.metatags.canonical` entry pointing at `https://docs.mixpanel.com` so search engines treat the production custom domain as authoritative. This consolidates SEO signal onto the new Mintlify domain (complementing the nginx 301s) and prevents duplicate-content indexing of the Mintlify preview URL.

Linear link: https://linear.app/mixpanel/issue/TOF-284/

# Test / Rollout plan
- After deploy, load any page on https://docs.mixpanel.com and view source; confirm `<link rel="canonical" href="https://docs.mixpanel.com/<page-path>">` is present with the correct per-page path.
- Spot-check a nested page (e.g. a guide under /docs/...) to verify the canonical path matches the page, not just the root domain.
- Rollback: revert this commit