### PR TITLE
Restructure CODEOWNERS for content vs engineering owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,16 @@
-# Default to docs reviewers
+# Documentation content → docs reviewers (default for everything)
 # ======================
-*                    @mixpanel/docs-reviewers
-.github/*            @mixpanel/tofu
+*                       @mixpanel/docs-reviewers
+
+# tofu or docs reviewers (either can approve)
+# ======================
+/docs.json              @mixpanel/tofu @mixpanel/docs-reviewers
+/style.css              @mixpanel/tofu @mixpanel/docs-reviewers
+/README.md              @mixpanel/tofu @mixpanel/docs-reviewers
+/.github/               @mixpanel/tofu @mixpanel/docs-reviewers
+/.gitignore             @mixpanel/tofu @mixpanel/docs-reviewers
+
+# Engineering-owned files → tofu only
+# ======================
+/csp.txt                @mixpanel/tofu
+/scripts/               @mixpanel/tofu


### PR DESCRIPTION
Restructures `.github/CODEOWNERS` so documentation content routes only to `@mixpanel/docs-reviewers`, while config/code files route to `@mixpanel/tofu`. This stops content authors from pinging engineering on every article edit, ahead of turning on "Require review from Code Owners" when the repo goes public.

- Default (`*`) → `@mixpanel/docs-reviewers`
- Either team may approve: `docs.json`, `style.css`, `README.md`, `.github/`, `.gitignore`
- tofu only: `csp.txt`, `scripts/`
- Fixes `.github` to a recursive pattern (old `.github/*` missed `.github/workflows/`)

Linear link: https://linear.app/mixpanel/issue/TOF-285/

# Test / Rollout plan
- Rollback: revert this commit; ownership reverts to all → docs-reviewers.