### PR TITLE
Re-host README logo locally and fix image-path docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-	<img width="150" src="https://github.com/mixpanel/docs/assets/71290498/1f5dfccf-8ba8-481a-8faa-c6c297d7d4c6" alt="Mixpanel">
+	<img width="150" src="images/mixpanel-logo.svg" alt="Mixpanel">
 	<h1>Mixpanel's Official Documentation</h1>
 	<p>
 		<b><a href="https://docs.mixpanel.com/">docs.mixpanel.com</a></b>
@@ -47,9 +47,9 @@ mintlify dev
 
 # Adding Images/GIFs
 
-Upload images/GIFs to the `image/` directory.
+Upload images/GIFs to the `images/` directory.
 
-To reference an image, use a relative link to the image For example, if you have an image `public/example.png`, you can reference it as follows: 
+To reference an image, use a relative link to the image. For example, if you have an image `images/example.png`, you can reference it as follows:
 
 ```
 <Frame>
@@ -57,7 +57,7 @@ To reference an image, use a relative link to the image For example, if you have
 </Frame>
 ```
 
-Ensure that the the image filename has no spaces and are separated by either a hyphen or an underscore.
+Ensure that the image filename has no spaces and are separated by either a hyphen or an underscore.
 
 If you're making a diagram, please add it to this [Figjam](https://www.figma.com/file/m4XseN6oAiu2yGN18qfamD/Docs-Toolkit?type=whiteboard&node-id=0-1&t=j3TBgane3MsYReF2-0). That way, if others want to make small tweaks, they can discover the original.
 

--- a/images/mixpanel-logo.svg
+++ b/images/mixpanel-logo.svg
@@ -1,0 +1,27 @@
+<svg width="400" height="400" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1360_121491)">
+<rect width="400" height="400" rx="24" fill="#1B0B3B"/>
+<path d="M152.876 181.597H181.558C174.396 177.117 171.715 170.837 168.117 159.195L157.357 119.311C152.435 101.389 148.396 92.8697 128.675 92.8697H87.4675V103.63H93.3058C105.39 103.63 106.747 108.11 110.345 121.552L119.748 156.513C124.669 173.553 132.307 181.597 152.91 181.597H152.876ZM219.235 181.597H247.883C268.487 181.597 275.649 173.519 280.605 156.513L290.007 121.552C293.605 108.11 295.37 103.63 307.047 103.63H312.885V92.8697H272.119C251.957 92.8697 247.917 100.948 243.437 119.311L232.677 159.195C229.079 171.279 226.397 177.117 219.235 181.597ZM181.558 219.207H219.236L219.235 181.597H181.558V219.207ZM87.4675 307.934H128.675C148.396 307.934 152.435 299.414 157.357 281.492L168.117 241.609C171.715 229.967 174.396 223.687 181.558 219.207H152.876C132.273 219.207 124.635 227.285 119.714 244.291L110.311 279.252C106.713 292.694 105.39 297.174 93.2718 297.174H87.4675V307.934ZM272.051 307.934H312.817V297.174H306.979C295.336 297.174 293.537 292.694 289.939 279.252L280.537 244.291C275.615 227.251 268.453 219.207 247.816 219.207H219.236C226.398 223.687 228.977 229.525 232.575 241.609L243.335 281.492C247.815 299.856 251.855 307.934 272.017 307.934H272.051Z" fill="#FBF9F9"/>
+<g filter="url(#filter0_f_1360_121491)">
+<ellipse cx="313.5" cy="-138.5" rx="113.5" ry="90.5" fill="#7856FF"/>
+</g>
+<g filter="url(#filter1_f_1360_121491)">
+<circle cx="122" cy="522" r="107" fill="#7856FF"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_f_1360_121491" x="0" y="-429" width="627" height="581" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="100" result="effect1_foregroundBlur_1360_121491"/>
+</filter>
+<filter id="filter1_f_1360_121491" x="-185" y="215" width="614" height="614" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="100" result="effect1_foregroundBlur_1360_121491"/>
+</filter>
+<clipPath id="clip0_1360_121491">
+<rect width="400" height="400" rx="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
Re-hosts the README header logo as a repo-local SVG so it doesn't break when `mixpanel-docs` is renamed to `docs`, and corrects stale image-path docs carried over from the old Nextra setup.

- Header logo now references `images/mixpanel-logo.svg` (relative path) instead of an attachment hosted in the old repo
- `Adding Images/GIFs`: `image/` → `images/`, and example `public/example.png` → `images/example.png`
- Minor typo/grammar fixes

Linear link: https://linear.app/mixpanel/issue/TOF-285/

# Test / Rollout plan
- View this PR's rendered README on GitHub and confirm the Mixpanel logo displays (identical square purple icon as before).
- Confirm the logo still resolves after the eventual `mixpanel-docs → docs` rename — the path is relative, so it follows the repo.
- Rollback: revert this commit; header reverts to the previous (soon-to-break) attachment URL.