### PR TITLE
Fix snippet CodeQL alerts and route .jsx review to tofu

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,4 @@
 # ======================
 /csp.txt                @mixpanel/tofu
 /scripts/               @mixpanel/tofu
+*.jsx                   @mixpanel/tofu

--- a/snippets/SelfGuidedTours.jsx
+++ b/snippets/SelfGuidedTours.jsx
@@ -108,7 +108,15 @@ export const SelfGuidedTours = ({ cards }) => {
   };
 
   const openInline = useCallback((url, title) => {
-    const safeTitle = title.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    const escapeHtml = (s) =>
+      String(s)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+    const safeTitle = escapeHtml(title);
+    const safeUrl = escapeHtml(url);
     const prevOverflow = document.body.style.overflow;
 
     const overlay = document.createElement("div");
@@ -143,7 +151,7 @@ export const SelfGuidedTours = ({ cards }) => {
         </div>
         <button data-sgt-close aria-label="Close" style="width:36px;height:36px;border-radius:12px;border:1px solid #D1D5DB;background:#FFFFFF;display:inline-flex;align-items:center;justify-content:center;cursor:pointer;font-size:22px;font-weight:500;color:#111827">&#215;</button>
       </div>
-      <iframe src="${url}" title="${safeTitle}" allow="clipboard-write; fullscreen" style="width:100%;flex:1;border:0"></iframe>
+      <iframe src="${safeUrl}" title="${safeTitle}" allow="clipboard-write; fullscreen" style="width:100%;flex:1;border:0"></iframe>
     `;
 
     overlay.appendChild(box);

--- a/snippets/VideoButtonWithModal/VideoButtonWithModal.jsx
+++ b/snippets/VideoButtonWithModal/VideoButtonWithModal.jsx
@@ -143,7 +143,14 @@ export const VideoButtonWithModal = ({ src, title = "Video about this feature", 
   };
 
   const getLoomShareURL = (embedURL) => {
-    if (!embedURL?.includes("loom.com")) return null;
+    if (!embedURL) return null;
+    let hostname;
+    try {
+      hostname = new URL(embedURL).hostname;
+    } catch {
+      return null;
+    }
+    if (hostname !== "loom.com" && !hostname.endsWith(".loom.com")) return null;
     return embedURL.replace("/embed/", "/share/");
   };
 


### PR DESCRIPTION
Resolves the two open CodeQL alerts in `snippets/` and routes future `.jsx` review to engineering: https://github.com/mixpanel/docs/security/code-scanning

- **VideoButtonWithModal.jsx** (High — `js/incomplete-url-substring-sanitization`): replace the `embedURL.includes("loom.com")` substring check in `getLoomShareURL` with real URL hostname parsing.
- **SelfGuidedTours.jsx** (Medium — `js/incomplete-html-attribute-sanitization`): escape `"`/`'` and apply it to both `title` and `url` before they're interpolated into the modal's `innerHTML` attributes.
- **CODEOWNERS**: route `*.jsx` to `@mixpanel/tofu` (technical component code), keeping `.mdx` content with docs-reviewers.

Linear link: https://linear.app/mixpanel/issue/TOF-285/

# Test / Rollout plan
Use this PR's Mintlify staging preview (bot comment):
- **SelfGuidedTours** — open [/guides/self-guided-tours](https://docs.mixpanel.com/guides/self-guided-tours): cards render, and clicking one opens the "Viewing Interactive Demo" modal with the correct title in the pill and the Navattic demo loading in the iframe (confirms the quote-escaping didn't break title/URL rendering).
- **VideoButtonWithModal (Loom path — the High fix)** — open [/changelogs](https://docs.mixpanel.com/changelogs) and find a Loom-backed entry (e.g. "Column charts" 2024-05-09, "Spark" 2024-03-27): confirm the **"Link to Demo"** link still appears and points to a `https://www.loom.com/share/...` URL.
- **VideoButtonWithModal (YouTube path — regression)** — on /changelogs, spot-check a YouTube entry: the "Watch the video" button still opens the modal and plays.
- Confirm the CodeQL check on this PR reports both snippet alerts resolved.
- After merge: both alerts auto-close in the Security tab, and the next `*.jsx` PR requests `@mixpanel/tofu`.
- Rollback: revert this commit (logic reverts; the two CodeQL alerts reopen).