### PR TITLE
Update asset URLs from docs to docs-legacy repository

### DIFF
--- a/docs/boards/templates.mdx
+++ b/docs/boards/templates.mdx
@@ -117,7 +117,7 @@ This template is meant to be used largely by teams that implemented Mixpanel ins
 <img
   width="923"
   alt="Implementation Monitoring and Data Governance"
-  src="https://github.com/mixpanel/docs/assets/136498120/6c21d6a2-bb33-4043-b762-6c4b64ccda1d"
+  src="https://github.com/mixpanel/docs-legacy/assets/136498120/6c21d6a2-bb33-4043-b762-6c4b64ccda1d"
 />
 
 ### Training Board for Champions to use to Educate Users
@@ -133,7 +133,7 @@ This template is meant to be used by Mixpanel Champions looking to train their t
 <img
   width="923"
   alt="Training Board for Champions to use to Educate Users"
-  src="https://github.com/mixpanel/docs/assets/136498120/1bf32c1d-1bc8-43e8-8efc-01c2ae56aea1"
+  src="https://github.com/mixpanel/docs-legacy/assets/136498120/1bf32c1d-1bc8-43e8-8efc-01c2ae56aea1"
 />
 
 ### Data Troubleshooting Guide for End Users
@@ -155,5 +155,5 @@ Below are various examples of some common questions or issues that Mixpanel end 
 <img
   width="921"
   alt="Data Troubleshooting Guide for End Users"
-  src="https://github.com/mixpanel/docs/assets/136498120/ed65ef6a-b080-4aa8-a54b-598d8ac2f982"
+  src="https://github.com/mixpanel/docs-legacy/assets/136498120/ed65ef6a-b080-4aa8-a54b-598d8ac2f982"
 />

--- a/docs/data-structure/property-reference/data-type.mdx
+++ b/docs/data-structure/property-reference/data-type.mdx
@@ -358,13 +358,13 @@ If you do not want to see “undefined” or "null" values in your report, you c
 2. Looking only at instances where the property in question “is set" - this will exclude values where you see "undefined" or "null":
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/1a2465e1-da8d-4fe4-937a-5753716129b3)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/1a2465e1-da8d-4fe4-937a-5753716129b3)
 </Frame>
 
 3. Directly exclude undefined or null values from an Insights visualization by hitting the exclude action:
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/4d010827-cc4e-4a11-9716-cd3bfbaebadd)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/4d010827-cc4e-4a11-9716-cd3bfbaebadd)
 </Frame>
 
 ### Empty String

--- a/docs/features/custom-events.mdx
+++ b/docs/features/custom-events.mdx
@@ -34,13 +34,13 @@ You can create a custom event containing "Ad Conversion" and "Ad Impression," an
 To view, edit, or delete any custom event, navigate to [Lexicon](/docs/data-governance/lexicon).
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/efc4b36e-d8d9-4699-8a48-98b793532b20)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/efc4b36e-d8d9-4699-8a48-98b793532b20)
 </Frame>
 
 In Lexicon, click on the **Custom Events** tab.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/fb4e1680-3b20-4f24-90de-0101cb097c54)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/fb4e1680-3b20-4f24-90de-0101cb097c54)
 </Frame>
 
 Here you can see a list of all the custom events in the project. Click on the **name** of the event to edit its details.
@@ -48,7 +48,7 @@ Here you can see a list of all the custom events in the project. Click on the *
 To delete a custom event, check the **box** beside the title of all the custom events you want to delete, then click the **delete** button at the top of the list.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/8004da2b-db3c-48c0-a494-e500e1cc5bf7)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/8004da2b-db3c-48c0-a494-e500e1cc5bf7)
 </Frame>
 
 ## Sharing Custom Events

--- a/docs/features/custom-properties.mdx
+++ b/docs/features/custom-properties.mdx
@@ -43,7 +43,7 @@ Note that the formula used to compose your custom property can't be longer than 
 </Note>
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/98a4e5f0-6b9b-414b-8dfe-feecdb837078)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/98a4e5f0-6b9b-414b-8dfe-feecdb837078)
 </Frame>
 </Step>
 </Steps>
@@ -74,7 +74,7 @@ You can also use the [Channel Classifier](/changelogs/2023-11-16-channel-classif
 If you have an e-commerce app, you can combine "price" and "quantity" properties into a "total price" property as follows:
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/b514f908-6838-45ff-bdea-feb6969e0340)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/b514f908-6838-45ff-bdea-feb6969e0340)
 </Frame>
 
 
@@ -85,7 +85,7 @@ Use custom properties to compute the date/time difference between two date prope
 A new custom property can be defined by taking into account the “Created” property and using the following transformation:
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/3f099385-9b2c-4e5c-9f73-e72a807e133e)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/3f099385-9b2c-4e5c-9f73-e72a807e133e)
 </Frame>
 
 **Compare Different Properties**
@@ -99,7 +99,7 @@ A company wants to find out what percentage of purchases are being made by users
 They can create a custom property to determine whether the two country values are the same with this transformation:
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/c9b2a70a-60d7-4563-9b59-b21d3c5b86cc)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/c9b2a70a-60d7-4563-9b59-b21d3c5b86cc)
 </Frame>
 
 **Extract Domain from Email Address**
@@ -107,7 +107,7 @@ They can create a custom property to determine whether the two country values ar
 Extract the domain of the email from an email address. You can parse out parts of a string after "@" using the SPLIT function:
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/daf38804-4bfc-40a4-bed2-8d391bd4ebda)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/daf38804-4bfc-40a4-bed2-8d391bd4ebda)
 </Frame>
 
 **Query a List with an Index**
@@ -117,7 +117,7 @@ Let's say you have a list of recommendations as a property, and you’d like to 
 You can parse out the first delivery ID in a list property with several DeliveryIDs:
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/7532e7ea-d9cb-44c1-aa8b-48a343ec3d9a)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/7532e7ea-d9cb-44c1-aa8b-48a343ec3d9a)
 </Frame>
 
 The same syntax works with objects.

--- a/docs/features/sessions.mdx
+++ b/docs/features/sessions.mdx
@@ -120,11 +120,11 @@ Sessions are reset every 24 hours at midnight (according to your project timezon
 Use your [Time to Convert Chart in Funnels](/docs/reports/funnels/funnels-advanced#time-to-convert) to help determine an appropriate session timeout period that aligns with your users’ behavior.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/44f40194-1aff-493b-828e-f9a1c750ac03)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/44f40194-1aff-493b-828e-f9a1c750ac03)
 </Frame>
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/2e831c9f-d3cc-4dcf-abb9-a741e22de34d)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/2e831c9f-d3cc-4dcf-abb9-a741e22de34d)
 </Frame>
 
 In your Funnel you can select the event that denotes a "Session Start" in your app (such as “Log In”), and the "Session End" event (such as “Log Out”). Check the time it takes users to convert from the start event to the end event in the Time to Convert Chart, and this will give you an indicator of the average amount of time a session lasts in your app.
@@ -304,13 +304,13 @@ You can add additional properties to be associated with the session by going und
 In [Funnels](/docs/reports/funnels/funnels-overview), once you have set up sessions, a “Session Start” and “Session End” events will be generated in the report based on the funnel criteria.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/e6c12438-00da-4ebe-8302-a52f5a9da511)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/e6c12438-00da-4ebe-8302-a52f5a9da511)
 </Frame>
 
 The event properties "Session Duration (Seconds)", "Session Event Count", "Session End Event Name", and "Session Start Event Name" can be used to break down or filter these results.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/5608f64b-3514-406f-8a65-fe6a588f36fb)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/5608f64b-3514-406f-8a65-fe6a588f36fb)
 </Frame>
 
 You can also choose to count Sessions instead of Uniques or Totals in the Conversion Details section. If you choose to count Sessions, the conversion window will be limited to one session.
@@ -318,13 +318,13 @@ You can also choose to count Sessions instead of Uniques or Totals in the Conver
 Whenever you make a change to session settings, you can then review the impact of this change in the Funnels Time to Convert Chart. If you see a large group of users doing 4+ hour sessions or just having sessions of \< 1 minute, you can create cohorts from these user segments and then evaluate their behavior in Flows to confirm Sessions is set up correctly.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/e986f4f1-ad96-408b-8217-2a979b66e9eb)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/e986f4f1-ad96-408b-8217-2a979b66e9eb)
 </Frame>
 
 If you choose to count Uniques or Totals, you will be able to select a conversion window as usual, including Sessions.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/d0be7cb4-9cd4-46cd-849e-af4687b6aa1c)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/d0be7cb4-9cd4-46cd-849e-af4687b6aa1c)
 </Frame>
 
 ### Flows
@@ -344,7 +344,7 @@ In [Insights](/docs/reports/insights), you can use the “Session Start” and �
 - Sessions calculated in formulas
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/ee999c27-c70f-438e-a95d-6ea4925b8474)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/ee999c27-c70f-438e-a95d-6ea4925b8474)
 </Frame>
 
 When you select sessions in Insights, you will be viewing total session counts, rather than uniques or totals.
@@ -356,7 +356,7 @@ The event properties "Session Duration (Seconds)", "Session Event Count", "Sessi
 In Insights, you can also count the number of sessions that contained a particular event. Select the **Total** drop-down beside an event in your Insights query to select **Sessions**.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/350c4606-4366-40af-a050-21cbe01bf543)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/350c4606-4366-40af-a050-21cbe01bf543)
 </Frame>
 
 For example, select an event that determines success for your company, such as "Product Purchase". Using this aggregation you can track how many sessions contained a purchase.

--- a/docs/reports.mdx
+++ b/docs/reports.mdx
@@ -57,13 +57,13 @@ An inline filter applies to one particular event in the report.
 Add a filter to your query by clicking on the **…** icon beside an event, profile, cohort, or step.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/3e36bd7e-f5b8-462a-890c-bf396ff98f69)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/3e36bd7e-f5b8-462a-890c-bf396ff98f69)
 </Frame>
 
 Then, select a property from the drop-down list that appears and specify which values to filter.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/c7cce429-3c9c-4759-8ea1-b09345fa0b4e)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/c7cce429-3c9c-4759-8ea1-b09345fa0b4e)
 </Frame>
 
 In Funnels, filtering a step by a particular property will limit the data you see in the funnel to events with that property value.
@@ -73,7 +73,7 @@ You can choose multiple property filters for each item in your query.
 You can select whether you would like the query to match any of these filters, or all of the filters, by clicking on **and/or** beside the filters.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/9e3bcd31-2b12-48d1-b04f-cdda85dd2584)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/9e3bcd31-2b12-48d1-b04f-cdda85dd2584)
 </Frame>
 
 ### First Time Ever Filter
@@ -146,7 +146,7 @@ You can select the following filtering options to show a subset of the propertie
 To duplicate any metrics or properties in your query, select the inline action menu and choose **Duplicate**. Delete any events or properties by clicking the **trash** icon.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/f496b609-47a3-4287-95f8-e9e6f2ac915d)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/f496b609-47a3-4287-95f8-e9e6f2ac915d)
 </Frame>
 
 ## Date Range
@@ -222,7 +222,7 @@ Enable hourly and minute-level granularity by going to the advanced submenu unde
 To zoom in, click on the graph and drag to highlight a specific window of time in your report. Click **Reset zoom** to return to the previous view.
 
 <Frame>
-![zoom (1)](https://github.com/mixpanel/docs/assets/2077899/3add64ad-3fea-4d74-a3bf-303fcc1f4d9d)
+![zoom (1)](https://github.com/mixpanel/docs-legacy/assets/2077899/3add64ad-3fea-4d74-a3bf-303fcc1f4d9d)
 </Frame>
 
 ## Comparisons

--- a/docs/reports/apps/impact.mdx
+++ b/docs/reports/apps/impact.mdx
@@ -42,13 +42,13 @@ Here are some of the sample questions you can answer in Impact:
 To build an Impact query, first select a launch event. This is the event that you are measuring as the cause of change.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/8ed06dad-4567-4fb0-8200-32d6a51cae0b)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/8ed06dad-4567-4fb0-8200-32d6a51cae0b)
 </Frame>
 
 Select the start date of this launch event. Add any additional filters to narrow the launch event parameters by clicking the **... dropdown** and selecting the **Add filter**.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/b1ed7f9e-eea4-49ea-a80d-fb3c776b16a3)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/b1ed7f9e-eea4-49ea-a80d-fb3c776b16a3)
 </Frame>
 
 ### Step 2: Select metric events
@@ -56,7 +56,7 @@ Select the start date of this launch event. Add any additional filters to narrow
 Select a metric event by clicking the **Add** button under **IMPACTED EVENTS**. You are measuring the impact of the launch event on this metric event. Add additional filters to narrow the impacted event parameters.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/d728738d-4869-4144-994f-05422772347c)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/d728738d-4869-4144-994f-05422772347c)
 </Frame>
 
 ### Step 3: Add breakdown (optional)
@@ -64,7 +64,7 @@ Select a metric event by clicking the **Add** button under **IMPACTED EVENTS*
 Breakdown impacted events further by clicking the **… icon**, selecting **Add Aggregation**, then selecting an event property, such as “Amount”. This will add up the value of this property for all of the times this event happened in this time range. All aggregate properties are typecast to numeric properties in order to calculate the sum of that property. For example, aggregate the property “Amount” under the event “Process Payment” to analyze revenue.
 
 <Frame>
-![gif](https://github.com/mixpanel/docs/assets/2077899/c341da61-a5c2-4b3f-aa0e-c23e8116e4d9)
+![gif](https://github.com/mixpanel/docs-legacy/assets/2077899/c341da61-a5c2-4b3f-aa0e-c23e8116e4d9)
 </Frame>
 
 ### Step 4: Select user group
@@ -72,7 +72,7 @@ Breakdown impacted events further by clicking the **… icon**, selecting **Ad
 Under **USER DEFINITION** select whether you would like to count users who did **only the impacted event** or **any event**.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/6d10e2bd-0167-4d09-b456-8aabbf49694d)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/6d10e2bd-0167-4d09-b456-8aabbf49694d)
 </Frame>
 
 ### Step 5: Select time range
@@ -82,7 +82,7 @@ Select the time range. The time range is a fixed period of time that determines 
 The chart will not necessarily change if you change the time range.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/a998a82f-0d8e-4a53-9ffb-69fdb87da137)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/a998a82f-0d8e-4a53-9ffb-69fdb87da137)
 </Frame>
 
 
@@ -103,7 +103,7 @@ The Impact Chart shows how the rate of metric event occurrence changes over time
 Unlike other Mixpanel charts, the Impact Chart displays time in relative time, not calendar time.  The chart centers around the first day that the launch event is available, or “day zero”. The chart displays the 15 days before and after day zero.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/3e1ebe51-eeaf-4322-bd44-04ca02518094)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/3e1ebe51-eeaf-4322-bd44-04ca02518094)
 </Frame>
 
 Every user in the report can have a different day zero.  For users in the adopter group, day zero is the first day that they perform the launch event.  For users in the non-adopter group, day zero is the day the first adopter performed the launch event (which is most likely the launch day of the feature).

--- a/docs/reports/apps/signal.mdx
+++ b/docs/reports/apps/signal.mdx
@@ -20,13 +20,13 @@ The music sharing app may want to understand the correlation between top events 
 Building this query in Signal would involve selecting the target users, and how the "Song Purchased" goal event is correlated with the top events.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/2baec3b5-ce5e-4d7d-9726-de131d05bfd2)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/2baec3b5-ce5e-4d7d-9726-de131d05bfd2)
 </Frame>
 
 Values are returned after running the correlation. “Song Played” could have a strong positive correlation with purchasing a song. Most of the users who played a song later purchased a song.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/3409f91a-ca07-4cd0-84c4-9105ee9024a0)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/3409f91a-ca07-4cd0-84c4-9105ee9024a0)
 </Frame>
 
 This information can be used in future product decisions. By knowing that those who play songs are more likely to purchase songs, it is possible to build tools to encourage song plays. This could lead to a dramatic increase in the amount of users purchasing songs.

--- a/docs/reports/flows.mdx
+++ b/docs/reports/flows.mdx
@@ -271,7 +271,7 @@ Top paths will show the 50 most common event sequences of up to the number of st
 The total percentage of users who reached the ultimate destination of a flow is indicated on the top left, while the total users that reached a given step and the percentage of users who converted from the previous step are indicated on the bottom of each step.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/c36fcfb5-edbb-4374-86fc-6e3d3f5aa316)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/c36fcfb5-edbb-4374-86fc-6e3d3f5aa316)
 </Frame>
 
 ### Expand Event by Property

--- a/docs/reports/insights.mdx
+++ b/docs/reports/insights.mdx
@@ -210,20 +210,20 @@ Tables are useful to see the precise values of your data and to quickly scan mul
 You can configure how you want rows in the table to be sorted, with our global sorting control.
 
 <Frame>
-![Sorting.gif](https://github.com/mixpanel/docs/assets/2077899/a61948a6-3e4a-4e5d-9b75-3f4b14cb1450)
+![Sorting.gif](https://github.com/mixpanel/docs-legacy/assets/2077899/a61948a6-3e4a-4e5d-9b75-3f4b14cb1450)
 </Frame>
 
 ###### Grouped View vs Ungrouped View
 The Ungrouped View removes all hierarchy and makes the table flat. Each combination of segment values is treated as a row, independently of the other rows.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/e57400a1-a86c-4d46-9ffb-379306586d8d)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/e57400a1-a86c-4d46-9ffb-379306586d8d)
 </Frame>
 
 The Grouped View preserves the hierarchy of breakdowns. It shows you segments within a breakdown as displayed below. This view is only applicable when you have 2 or more breakdowns
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/2a72e93c-c332-4418-83e1-91bb24e2d271)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/2a72e93c-c332-4418-83e1-91bb24e2d271)
 </Frame>
 
 ###### Alphabetical vs Value-Based Sorting
@@ -232,7 +232,7 @@ You can sort segments alphabetically or by the value of a particular metric. In 
 In the below image, we sort Country *within* Item Category, which respects the hierarchy.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/4697ce00-d394-46ce-b538-66ec91ccd6e7)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/4697ce00-d394-46ce-b538-66ec91ccd6e7)
 </Frame>
 
 Hierarchy is defined by the breakdown order in the query panel.
@@ -243,13 +243,13 @@ Hierarchy is defined by the breakdown order in the query panel.
 **Overall:** This refers to the value considering all the segments, independent of whether displayed or not based on your View N control; i.e changes to View N will not affect Overall numbers
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/3d6556a4-9468-4d1f-8979-4fdb512f2aaa)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/3d6556a4-9468-4d1f-8979-4fdb512f2aaa)
 </Frame>
 
 **Sub-Totals:** In the grouped view, in addition to the Overall, segment sub-totals are also displayed. Similar to “Overall”, these values are independent of the View N control
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/ee7d8c9b-f738-4a5b-8967-300cf8322f76)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/ee7d8c9b-f738-4a5b-8967-300cf8322f76)
 </Frame>
 
 
@@ -264,23 +264,23 @@ Dynamic Segments let you decide how many segments to display per breakdown in yo
 When using Dynamic Segments, you can select the number of segments to display from the column headers. 
 
 <Frame>
-![View_N_gif](https://github.com/mixpanel/docs/assets/2077899/4fb0fd18-2ef7-416b-adaa-c7299da0f7b3)
+![View_N_gif](https://github.com/mixpanel/docs-legacy/assets/2077899/4fb0fd18-2ef7-416b-adaa-c7299da0f7b3)
 </Frame>
 
 In the ungrouped view, choose the number of rows to display:
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/b1b25b19-51be-4934-bbfd-7562e0f98d4a)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/b1b25b19-51be-4934-bbfd-7562e0f98d4a)
 </Frame>
 
 In the grouped view, you can choose the number of rows you want to display for each breakdown:
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/f9f8c83c-34ed-44bd-b4e7-f60b70255a6f)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/f9f8c83c-34ed-44bd-b4e7-f60b70255a6f)
 </Frame>
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/b09c1ad1-1392-4ec0-9358-361f677c600d)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/b09c1ad1-1392-4ec0-9358-361f677c600d)
 </Frame>
 
 **Notes about Dynamic Segments**

--- a/docs/tracking-methods/integrations/ad-spend.mdx
+++ b/docs/tracking-methods/integrations/ad-spend.mdx
@@ -7,7 +7,7 @@ Mixpanel’s event-based data model enables you to represent and analyze any typ
 In this doc, we give step-by-step guidance on how to bring your advertising network data into Mixpanel to look at metrics such as ROAS (Return on Ad Spend), CPC (Cost per click) in the context of in-product conversions. We also provide detailed guides for Google and Facebook Ads. The end result should look like this:
 
 <Frame>
-![](https://github.com/mixpanel/docs/assets/2077899/84e1c6a1-0130-4529-9be3-5574a73dffac)
+![](https://github.com/mixpanel/docs-legacy/assets/2077899/84e1c6a1-0130-4529-9be3-5574a73dffac)
 </Frame>
 
 
@@ -182,7 +182,7 @@ The last piece of information we will need is the Client Customer ID. It is the 
 
 Log into [Google Ads](https://ads.google.com/), and note the numbers at the top right of the screen under your display name.
 <Frame>
-![Untitled](https://github.com/mixpanel/docs/assets/2077899/baae1f78-2640-4552-b470-71d0d00ae60f)
+![Untitled](https://github.com/mixpanel/docs-legacy/assets/2077899/baae1f78-2640-4552-b470-71d0d00ae60f)
 </Frame>
 
 It should look something like: `123-456-7890`.

--- a/docs/tracking-methods/integrations/segment.mdx
+++ b/docs/tracking-methods/integrations/segment.mdx
@@ -170,7 +170,7 @@ There are 4 parts to implementing Group Analytics via Segment. Learn more about 
 Create the Group Key in Mixpanel Project Settings. In this example, we are setting `company_id` as the group key.
 
 <Frame>
-![1groupkey_projectsettings](https://github.com/mixpanel/docs/assets/97630035/835de9fa-eea2-47b0-9965-4a922ebd39ab)
+![1groupkey_projectsettings](https://github.com/mixpanel/docs-legacy/assets/97630035/835de9fa-eea2-47b0-9965-4a922ebd39ab)
 </Frame>
 
 **2. Configure your Group Actions Mapping**
@@ -206,7 +206,7 @@ analytics.group("some_company", {
 Example Group Profile/Group Profile Properties created from the group method above:
 
 <Frame>
-![4groupprofile](https://github.com/mixpanel/docs/assets/97630035/b8b7ab18-4c65-4dff-965a-d532ae49cffc)
+![4groupprofile](https://github.com/mixpanel/docs-legacy/assets/97630035/b8b7ab18-4c65-4dff-965a-d532ae49cffc)
 </Frame>
 
 **4. Add Group Key as a User Profile Property**
@@ -215,7 +215,7 @@ In order to use Group Profile Properties when analyzing User Profiles, the user 
 
 Declare the Group Key in the identify method as a profile property (trait):
 <Frame>
-![5identify](https://github.com/mixpanel/docs/assets/97630035/41cc54c4-2e52-4e77-833d-cc178d1fb107)
+![5identify](https://github.com/mixpanel/docs-legacy/assets/97630035/41cc54c4-2e52-4e77-833d-cc178d1fb107)
 </Frame>
 
 **5. Add Group Key as an Event Property to Events**
@@ -225,7 +225,7 @@ In order to connect events to a Group, the event must have the Group Key/Group I
 The Group Key must be explicitly declared as an event property on every event track call in order for the event to be compatible with Group Analytics.
 
 <Frame>
-![6trackcall](https://github.com/mixpanel/docs/assets/97630035/9609917d-f00b-4450-a9d5-7d77bd338f9d)
+![6trackcall](https://github.com/mixpanel/docs-legacy/assets/97630035/9609917d-f00b-4450-a9d5-7d77bd338f9d)
 </Frame>
 
 If you are using [Segment Device Mode](https://segment.com/docs/connections/destinations/catalog/mixpanel/#group-using-device-mode) (Classic destination):
@@ -236,12 +236,12 @@ If you are using [Segment Device Mode](https://segment.com/docs/connections/dest
 ## Debugging
 For debugging purposes, it can be useful to see exactly what Segment is sending to Mixpanel. You can validate this data through the [Segment Source Debugger](https://segment.com/docs/connections/sources/debugger/). In the Segment Source Debugger, you can select the event you are looking to validate:
 <Frame>
-<img width="1080" alt="debugger screenshot" src="https://github.com/mixpanel/docs/assets/97630035/6ee0bbcd-8bf2-4f86-83a7-b0a3c39108e4" />
+<img width="1080" alt="debugger screenshot" src="https://github.com/mixpanel/docs-legacy/assets/97630035/6ee0bbcd-8bf2-4f86-83a7-b0a3c39108e4" />
 </Frame>
 
 Click the “Validate” button in the top right corner and choose “Mixpanel” as the destination. After the event has been sent, you can click to view the request from Segment to grab the data payload:
 <Frame>
-![pasted image 0 (1)](https://github.com/mixpanel/docs/assets/97630035/0344decc-dc96-4569-ac3d-cc530c63bdb3)
+![pasted image 0 (1)](https://github.com/mixpanel/docs-legacy/assets/97630035/0344decc-dc96-4569-ac3d-cc530c63bdb3)
 </Frame>
 
 You can then copy the data payload and decode it in a [base64 decoder](https://www.base64decode.org/) to see the JSON event that was sent to Mixpanel.

--- a/docs/tracking-methods/integrations/tealium.mdx
+++ b/docs/tracking-methods/integrations/tealium.mdx
@@ -35,31 +35,31 @@ In order to trigger Mixpanel events based on the values of `tealium_event`s, you
 Find "data layer" in the main menu:
 
 <Frame>
-![01-dataLayerMenu](https://github.com/mixpanel/docs/assets/3978760/c99badbe-8755-42c6-8052-0af1dd873a44)
+![01-dataLayerMenu](https://github.com/mixpanel/docs-legacy/assets/3978760/c99badbe-8755-42c6-8052-0af1dd873a44)
 </Frame>
 
 Click "add variable":
 
 <Frame>
-![02-addVar](https://github.com/mixpanel/docs/assets/3978760/ec812663-885f-4568-95c6-f61cfb22315c)
+![02-addVar](https://github.com/mixpanel/docs-legacy/assets/3978760/ec812663-885f-4568-95c6-f61cfb22315c)
 </Frame>
 
 The type is "UDO Variable"; the source is "tealium_event" ... then click apply:
 
 <Frame>
-![03-UDOVar](https://github.com/mixpanel/docs/assets/3978760/b810e6f3-8316-4045-9aab-b4a1f05163e8)
+![03-UDOVar](https://github.com/mixpanel/docs-legacy/assets/3978760/b810e6f3-8316-4045-9aab-b4a1f05163e8)
 </Frame>
 
 Now save and publish!
 
 <Frame>
-![04-SavePublish](https://github.com/mixpanel/docs/assets/3978760/976a8c20-ef40-4c0b-9d7d-d5cfdb1baec2)
+![04-SavePublish](https://github.com/mixpanel/docs-legacy/assets/3978760/976a8c20-ef40-4c0b-9d7d-d5cfdb1baec2)
 </Frame>
 
 You should now see a "tealium_event" variable in your UDOs:
 
 <Frame>
-![05-TealiumEvent](https://github.com/mixpanel/docs/assets/3978760/d4d4f6e3-7ee2-4ac3-a6a7-cdb5c6c1b12f)
+![05-TealiumEvent](https://github.com/mixpanel/docs-legacy/assets/3978760/d4d4f6e3-7ee2-4ac3-a6a7-cdb5c6c1b12f)
 </Frame>
 
 ( ^ it should look exactly like this! ^)
@@ -71,19 +71,19 @@ You are now ready to setup mixpanel events with triggers based on the *values* p
 - Find the **tags** section of iQ Tag Manager:
 
 <Frame>
-![06-NewTags](https://github.com/mixpanel/docs/assets/3978760/96522330-67a8-437e-bb6e-3fd2cc89df27)
+![06-NewTags](https://github.com/mixpanel/docs-legacy/assets/3978760/96522330-67a8-437e-bb6e-3fd2cc89df27)
 </Frame>
 
 - Click **add tags** and find 'mixpanel' using the search
 
 <Frame>
-![07-AddTag](https://github.com/mixpanel/docs/assets/3978760/88f75984-4717-475b-bdaf-85156fbc33f8)
+![07-AddTag](https://github.com/mixpanel/docs-legacy/assets/3978760/88f75984-4717-475b-bdaf-85156fbc33f8)
 </Frame>
 
  - Click **add** to bring the Mixpanel tag into your Tealium workspace.
 
 <Frame>
-![08-Mixpanel](https://github.com/mixpanel/docs/assets/3978760/ad7b8de6-727c-43e6-a21f-50e3713af16c)
+![08-Mixpanel](https://github.com/mixpanel/docs-legacy/assets/3978760/ad7b8de6-727c-43e6-a21f-50e3713af16c)
 </Frame>
 
 You can now connect your Mixpanel project to Tealium and configure the tag's behavior.
@@ -93,7 +93,7 @@ You will need a [mixpanel account](https://mixpanel.com/register/) and a [mixpan
 In the first section of the tag wizard, enter your [**mixpanel project token**](https://help.mixpanel.com/hc/en-us/articles/115004502806-Find-Project-Token-) and click Next:
 
 <Frame>
-![09-ConnectingTags](https://github.com/mixpanel/docs/assets/3978760/272c360b-74ab-4561-b321-54faca49845e)
+![09-ConnectingTags](https://github.com/mixpanel/docs-legacy/assets/3978760/272c360b-74ab-4561-b321-54faca49845e)
 </Frame>
 
 Next, you’ll setup **load rules** which determine which pages mixpanel will be deployed on.
@@ -103,7 +103,7 @@ In order for the mixpanel tag to appear on your pages, you will need to add a co
 For testing, it’s perfectly fine to say "load on all pages":
 
 <Frame>
-![10-LoadRules](https://github.com/mixpanel/docs/assets/3978760/78f6ce2d-6546-48f2-834a-ea48e981999c)
+![10-LoadRules](https://github.com/mixpanel/docs-legacy/assets/3978760/78f6ce2d-6546-48f2-834a-ea48e981999c)
 </Frame>
 
 Mixpanel should now be deployed on all known Tealium pages of your site. Next, you will set up mappings which fire Mixpanel events based on mappings created in Tealium.
@@ -134,7 +134,7 @@ Here’s how you can setup this mapping:
 - Click "variables" dropdown and choose "tealium_event"
 
 <Frame>
-![11-Variables](https://github.com/mixpanel/docs/assets/3978760/c8c32537-50ac-4af1-ba36-a8be34bd9180)
+![11-Variables](https://github.com/mixpanel/docs-legacy/assets/3978760/c8c32537-50ac-4af1-ba36-a8be34bd9180)
 </Frame>
 
 - Bind the trigger `page_view` (from the UDO `tealium_event`) *to* the mixpanel method `track`:
@@ -142,13 +142,13 @@ Here’s how you can setup this mapping:
 - Click 'add’ when it looks like this... and then done
 
 <Frame>
-![12-Categories](https://github.com/mixpanel/docs/assets/3978760/e98f5fa3-8cf6-4be8-8a21-8ebcacdff277)
+![12-Categories](https://github.com/mixpanel/docs-legacy/assets/3978760/e98f5fa3-8cf6-4be8-8a21-8ebcacdff277)
 </Frame>
 
 - You should now have this binding:
 
 <Frame>
-![13-Binding](https://github.com/mixpanel/docs/assets/3978760/96d8e794-0979-441a-be68-c2cfb471630b)
+![13-Binding](https://github.com/mixpanel/docs-legacy/assets/3978760/96d8e794-0979-441a-be68-c2cfb471630b)
 </Frame>
 
 This will track the UDO `page_view` wherever it appears on our site.
@@ -160,19 +160,19 @@ For this tutorial, we’ll use a **[custom value](https://docs.tealium.com/iq-ta
 - Click "variables" drop down and choose use custom value:
 
 <Frame>
-![14-CustomValue](https://github.com/mixpanel/docs/assets/3978760/523c41dd-fe1f-42a5-b960-7212f7889693)
+![14-CustomValue](https://github.com/mixpanel/docs-legacy/assets/3978760/523c41dd-fe1f-42a5-b960-7212f7889693)
 </Frame>
 
 - Define your "custom value"
 
 <Frame>
-![15-CustomText](https://github.com/mixpanel/docs/assets/3978760/11e51314-042e-41a8-ad06-eae042cd1747)
+![15-CustomText](https://github.com/mixpanel/docs-legacy/assets/3978760/11e51314-042e-41a8-ad06-eae042cd1747)
 </Frame>
 
 - Now, in the **event parameters** menu bind our custom value `hello... from tealium` to the `eventName` for `track`:
 
 <Frame>
-![16-AddAndDone](https://github.com/mixpanel/docs/assets/3978760/31a484d3-247f-4dfc-8c48-f0bf1dc78ad2)
+![16-AddAndDone](https://github.com/mixpanel/docs-legacy/assets/3978760/31a484d3-247f-4dfc-8c48-f0bf1dc78ad2)
 </Frame>
 
 - Click "add" and "done" when you’ve mapped your custom value to Track : Event Name
@@ -180,13 +180,13 @@ For this tutorial, we’ll use a **[custom value](https://docs.tealium.com/iq-ta
 Our final mapping now looks like this:
 
 <Frame>
-![17-FinalMapping](https://github.com/mixpanel/docs/assets/3978760/c5c1f92b-2c74-4313-8df0-f76a5c046e41)
+![17-FinalMapping](https://github.com/mixpanel/docs-legacy/assets/3978760/c5c1f92b-2c74-4313-8df0-f76a5c046e41)
 </Frame>
 
 If your screen looks similar, you’re ready to save and publish!
 
 <Frame>
-![18-SaveAndDone](https://github.com/mixpanel/docs/assets/3978760/e18e645a-58ff-479e-b731-062d2f346b0a)
+![18-SaveAndDone](https://github.com/mixpanel/docs-legacy/assets/3978760/e18e645a-58ff-479e-b731-062d2f346b0a)
 </Frame>
 
 Wait a couple moments for tealium to apply the updates to your environment, and then load one of your pages (that has this tag deployed) 
@@ -194,7 +194,7 @@ Wait a couple moments for tealium to apply the updates to your environment, and 
 Pop open the developer console in your browser... you can see two requests to mixpanel:
 
 <Frame>
-![19-debugging](https://github.com/mixpanel/docs/assets/3978760/4b41ba9a-d669-4ac7-80de-00b273644d95)
+![19-debugging](https://github.com/mixpanel/docs-legacy/assets/3978760/4b41ba9a-d669-4ac7-80de-00b273644d95)
 </Frame>
 
 If you’re using a [tealium browser extension debugger,](https://chrome.google.com/webstore/detail/tealium-tools/gidnphnamcemailggkemcgclnjeeokaa?hl=en-US) or have forced the utag into [debug mode by modifying the cookie](https://docs.tealium.com/platforms/javascript/debugging/#debug-mode):
@@ -206,13 +206,13 @@ document.cookie="utagdb=true";
 You can see the tag’s rendering states:
 
 <Frame>
-![20-debugStates](https://github.com/mixpanel/docs/assets/3978760/ac51bae7-d4b4-45d0-817a-1053a6ef7763)
+![20-debugStates](https://github.com/mixpanel/docs-legacy/assets/3978760/ac51bae7-d4b4-45d0-817a-1053a6ef7763)
 </Frame>
 
 Or... you can skip all that debugging noise and just go to mixpanel, and click into the [events report](https://help.mixpanel.com/hc/en-us/articles/4402837164948-Events-formerly-Live-View-) to see your new fresh event!
 
 <Frame>
-![21-MixpanelEvents](https://github.com/mixpanel/docs/assets/3978760/28dfb81d-4a72-4177-938c-109a6194e981)
+![21-MixpanelEvents](https://github.com/mixpanel/docs-legacy/assets/3978760/28dfb81d-4a72-4177-938c-109a6194e981)
 </Frame>
 
 You just implemented Tealium → Mixpanel. You will repeat this process for additional events you wish to create.
@@ -225,19 +225,19 @@ Because Tealium wraps the Mixpanel JS SDK, Mixpanel's [default event properties]
 Any "custom" event properties will need to be mapped within Tealium using he following structure: **MY UDO ⇒**  **`track.properties.KEY_NAME`** where `KEY_NAME` is the **label** you want to use for the **property key in mixpanel**... the **value** will be the value of the UDO at runtime:
 
 <Frame>
-![22-NewProps](https://github.com/mixpanel/docs/assets/3978760/2772f1dc-45b7-4089-92bf-f042ac61bdff)
+![22-NewProps](https://github.com/mixpanel/docs-legacy/assets/3978760/2772f1dc-45b7-4089-92bf-f042ac61bdff)
 </Frame>
 
 A single event may have many custom properties mapped; that might look like this:
 
 <Frame>
-![23-MultipleMappings](https://github.com/mixpanel/docs/assets/3978760/4878ea4e-c2fa-4bc7-b5f5-72da3f969a08)
+![23-MultipleMappings](https://github.com/mixpanel/docs-legacy/assets/3978760/4878ea4e-c2fa-4bc7-b5f5-72da3f969a08)
 </Frame>
 
 Adding event properties is as simple as modifying the existing mapping to an event, and saving and publishing. Once you trigger your new tag you will the correct UDO value *and* the label you specified in the mapper show up in mixpanel  
 
 <Frame>
-![24-SuccessfulEvent](https://github.com/mixpanel/docs/assets/3978760/41d27add-4d89-424d-830e-ba978e3b17f6)
+![24-SuccessfulEvent](https://github.com/mixpanel/docs-legacy/assets/3978760/41d27add-4d89-424d-830e-ba978e3b17f6)
 </Frame>
 
 Note: you can always rename property keys' display labels [in lexicon](https://help.mixpanel.com/hc/en-us/articles/360001307806-Lexicon-Overview#adding-or-changing-descriptions)
@@ -261,31 +261,31 @@ It’s critically important that this value uniquely identifies the end-user
 - Assuming we have a UDO (or other javascript variable) that points to our UUID (unique user identifier)
 
 <Frame>
-![25-IdentityStart](https://github.com/mixpanel/docs/assets/3978760/d916c42d-5055-48ee-9fc1-11c547ac3b03)
+![25-IdentityStart](https://github.com/mixpanel/docs-legacy/assets/3978760/d916c42d-5055-48ee-9fc1-11c547ac3b03)
 </Frame>
 
 - Next, instruct Tealium when to use our `identify` tag... this is similar to how we used `page_view:track` directive to tell tealium to call `.track()` on the "tealium event" "page_view" ... you will probably use some other UDO event here (like `log in` or `sign in`):
     
 <Frame>
-![26-IdentityMap](https://github.com/mixpanel/docs/assets/3978760/a1cc3d9e-ff89-4491-a9b5-6d565ac68b4a)
+![26-IdentityMap](https://github.com/mixpanel/docs-legacy/assets/3978760/a1cc3d9e-ff89-4491-a9b5-6d565ac68b4a)
 </Frame>
 
     
 - Select the `id_of_user` UDO (or whatever value represents our UUID for the end user) in the dropdown and proceed to **SELECT DESTINATION**
     
 <Frame>
-![27-IdentityAdd](https://github.com/mixpanel/docs/assets/3978760/202e8a8c-8229-4c20-b8e8-5bf468e1d95b)
+![27-IdentityAdd](https://github.com/mixpanel/docs-legacy/assets/3978760/202e8a8c-8229-4c20-b8e8-5bf468e1d95b)
 </Frame>
 
 - Finally, map the `id_of_user` value to `event parameters` for the `identify` event and choose the specific parameter `unique ID` ... then click **ADD**
 
 <Frame>
-![28-IdentityFinish](https://github.com/mixpanel/docs/assets/3978760/89ae1139-7c65-4cf7-af0c-d8f6076a351c)
+![28-IdentityFinish](https://github.com/mixpanel/docs-legacy/assets/3978760/89ae1139-7c65-4cf7-af0c-d8f6076a351c)
 </Frame>
 
 A final implementation of mixpanel within Tealium might look like this:
 
 <Frame>
-![29-SampleComplete](https://github.com/mixpanel/docs/assets/3978760/7f5426d4-bbe3-4686-bfcd-e776b4475482)
+![29-SampleComplete](https://github.com/mixpanel/docs-legacy/assets/3978760/7f5426d4-bbe3-4686-bfcd-e776b4475482)
 </Frame>
 

--- a/docs/tracking-methods/sdks/javascript.mdx
+++ b/docs/tracking-methods/sdks/javascript.mdx
@@ -952,7 +952,7 @@ mixpanel.init('YOUR_PROJECT_TOKEN', {
 You can route events from Mixpanel's SDKs via a proxy in your own domain, which can reduce the likelihood of ad-blockers impacting your tracking.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/3ec6f3c2-aed0-4a18-9395-36838c3b53f1)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/3ec6f3c2-aed0-4a18-9395-36838c3b53f1)
 </Frame>
 
 There are two steps: setting up a proxy server and pointing our JavaScript SDK at your server.

--- a/docs/tracking-methods/sdks/react-native.mdx
+++ b/docs/tracking-methods/sdks/react-native.mdx
@@ -710,7 +710,7 @@ mixpanel.setUseIpAddressForGeolocation(false);
 You can route events from Mixpanel's SDKs via a proxy in your own domain, which can reduce the likelihood of ad-blockers impacting your tracking.
 
 <Frame>
-![image](https://github.com/mixpanel/docs/assets/2077899/3ec6f3c2-aed0-4a18-9395-36838c3b53f1)
+![image](https://github.com/mixpanel/docs-legacy/assets/2077899/3ec6f3c2-aed0-4a18-9395-36838c3b53f1)
 </Frame>
 
 There are two steps: setting up a proxy server and pointing our JavaScript SDK at your server.

--- a/snippets/changelogs/2023-06-06-ad-data.mdx
+++ b/snippets/changelogs/2023-06-06-ad-data.mdx
@@ -10,7 +10,7 @@ date: "2023-06-06"
 ## Track key ad metrics
 
 <Frame>
-![ad_spend](https://github.com/mixpanel/docs/assets/130083255/1d171623-615f-4b47-a54d-883306fcd30c)
+![ad_spend](https://github.com/mixpanel/docs-legacy/assets/130083255/1d171623-615f-4b47-a54d-883306fcd30c)
 </Frame>
 
 It’s easier than ever to start sending ad network data to Mixpanel with our [how-to guide](/docs/tracking-methods/integrations/ad-spend). 

--- a/snippets/changelogs/2023-06-06-web-tracking.mdx
+++ b/snippets/changelogs/2023-06-06-web-tracking.mdx
@@ -10,7 +10,7 @@ date: "2023-06-06"
 ## Learn how users engage with your marketing tactics
 
 <Frame>
-![webtracking](https://github.com/mixpanel/docs/assets/130083255/799423bf-aeec-431d-bbe1-08ad9e6ac9d9)
+![webtracking](https://github.com/mixpanel/docs-legacy/assets/130083255/799423bf-aeec-431d-bbe1-08ad9e6ac9d9)
 </Frame>
 
 Your analysis is only as good as the data you capture, and we work hard to make it easy to setup the right data tracking to get you to insights quick and easy.


### PR DESCRIPTION
Replace https://github.com/mixpanel/docs/assets/ with https://github.com/mixpanel/docs-legacy/assets/ across all documentation files since the repository was renamed.