### PR TITLE
[TOF-290] Make /hc/ help-center redirects slug-tolerant

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1630,1027 +1630,1027 @@
       "destination": "https://mixpanelsupport.zendesk.com/attachments/token/:path*"
     },
     {
-      "source": "/hc/articles/360000679006/:path*",
+      "source": "/hc/articles/360000679006*",
       "destination": "/docs/privacy/protecting-user-data"
     },
     {
-      "source": "/hc/en-us/articles/10147279357076/:path*",
+      "source": "/hc/en-us/articles/10147279357076*",
       "destination": "/docs/debugging/overview#data-discrepancies"
     },
     {
-      "source": "/hc/en-us/articles/10503460589972/:path*",
+      "source": "/hc/en-us/articles/10503460589972*",
       "destination": "/changelogs"
     },
     {
-      "source": "/hc/en-us/articles/10997736335892/:path*",
+      "source": "/hc/en-us/articles/10997736335892*",
       "destination": "https://github.com/mixpanel/mixpanel-js/blob/master/doc/readme.io/javascript-full-api-reference.md#mixpaneltime_event"
     },
     {
-      "source": "/hc/en-us/articles/115004474143/:path*",
+      "source": "/hc/en-us/articles/115004474143*",
       "destination": "/docs/orgs-and-projects/organizations#sso-via-okta"
     },
     {
-      "source": "/hc/en-us/articles/115004485966/:path*",
+      "source": "/hc/en-us/articles/115004485966*",
       "destination": "/docs/orgs-and-projects/organizations#two-factor-authentication-2fa"
     },
     {
-      "source": "/hc/en-us/articles/115004490503/:path*",
+      "source": "/hc/en-us/articles/115004490503*",
       "destination": "/docs/orgs-and-projects/managing-projects#viewing-project-information"
     },
     {
-      "source": "/hc/en-us/articles/115004490583/:path*",
+      "source": "/hc/en-us/articles/115004490583*",
       "destination": "/docs/pricing#view-events-usage"
     },
     {
-      "source": "/hc/en-us/articles/115004490963/:path*",
+      "source": "/hc/en-us/articles/115004490963*",
       "destination": "/docs/what-is-mixpanel"
     },
     {
-      "source": "/hc/en-us/articles/115004491123/:path*",
+      "source": "/hc/en-us/articles/115004491123*",
       "destination": "/docs/pricing#troubleshoot-payment-issues"
     },
     {
-      "source": "/hc/en-us/articles/115004491523/:path*",
+      "source": "/hc/en-us/articles/115004491523*",
       "destination": "/docs/best-practices/developer-environments#send-data-to-multiple-projects"
     },
     {
-      "source": "/hc/en-us/articles/115004491683/:path*",
+      "source": "/hc/en-us/articles/115004491683*",
       "destination": "/docs/best-practices/developer-environments#when-to-use-multiple-production-projects"
     },
     {
-      "source": "/hc/en-us/articles/115004493763/:path*",
+      "source": "/hc/en-us/articles/115004493763*",
       "destination": "/docs/orgs-and-projects/managing-projects#merge-or-combine-mixpanel-projects"
     },
     {
-      "source": "/hc/en-us/articles/115004494783/:path*",
+      "source": "/hc/en-us/articles/115004494783*",
       "destination": "https://mixpanel.com/legal/privacy-policy"
     },
     {
-      "source": "/hc/en-us/articles/115004494803/:path*",
+      "source": "/hc/en-us/articles/115004494803*",
       "destination": "/docs/privacy/protecting-user-data#disabling-geolocation"
     },
     {
-      "source": "/hc/en-us/articles/115004495783/:path*",
+      "source": "/hc/en-us/articles/115004495783*",
       "destination": "/docs/tracking-methods/id-management/identifying-users"
     },
     {
-      "source": "/hc/en-us/articles/115004497803/:path*",
+      "source": "/hc/en-us/articles/115004497803*",
       "destination": "/docs/tracking-methods/id-management/identifying-users"
     },
     {
-      "source": "/hc/en-us/articles/115004499343/:path*",
+      "source": "/hc/en-us/articles/115004499343*",
       "destination": "/docs/best-practices/server-side-best-practices#tracking-geolocation"
     },
     {
-      "source": "/hc/en-us/articles/115004499403/:path*",
+      "source": "/hc/en-us/articles/115004499403*",
       "destination": "/docs/features/advanced#undefined-and-null-properties"
     },
     {
-      "source": "/hc/en-us/articles/115004499463/:path*",
+      "source": "/hc/en-us/articles/115004499463*",
       "destination": "/docs/tracking-methods/sdks/javascript#how-to-set-up-a-proxy"
     },
     {
-      "source": "/hc/en-us/articles/115004501926/:path*",
+      "source": "/hc/en-us/articles/115004501926*",
       "destination": "/docs/pricing#what-if-i-go-over-my-event-plan-allowance"
     },
     {
-      "source": "/hc/en-us/articles/115004501966/:path*",
+      "source": "/hc/en-us/articles/115004501966*",
       "destination": "/docs/data-structure/user-profiles"
     },
     {
-      "source": "/hc/en-us/articles/115004502206/:path*",
+      "source": "/hc/en-us/articles/115004502206*",
       "destination": "/docs/pricing#what-if-i-go-over-my-event-plan-allowance"
     },
     {
-      "source": "/hc/en-us/articles/115004502806/:path*",
+      "source": "/hc/en-us/articles/115004502806*",
       "destination": "/docs/quickstart/install-mixpanel"
     },
     {
-      "source": "/hc/en-us/articles/115004505106/:path*",
+      "source": "/hc/en-us/articles/115004505106*",
       "destination": "/docs/orgs-and-projects/managing-projects#creating-projects"
     },
     {
-      "source": "/hc/en-us/articles/115004507523/:path*",
+      "source": "/hc/en-us/articles/115004507523*",
       "destination": "https://mixpanel.com/compare-to/google-analytics"
     },
     {
-      "source": "/hc/en-us/articles/115004507543/:path*",
+      "source": "/hc/en-us/articles/115004507543*",
       "destination": "/docs/what-to-track"
     },
     {
-      "source": "/hc/en-us/articles/115004509406/:path*",
+      "source": "/hc/en-us/articles/115004509406*",
       "destination": "/docs/tracking-methods/id-management/identifying-users"
     },
     {
-      "source": "/hc/en-us/articles/115004509426/:path*",
+      "source": "/hc/en-us/articles/115004509426*",
       "destination": "/docs/tracking-methods/id-management/identifying-users"
     },
     {
-      "source": "/hc/en-us/articles/115004510946/:path*",
+      "source": "/hc/en-us/articles/115004510946*",
       "destination": "/docs/tracking-methods/id-management/identifying-users"
     },
     {
-      "source": "/hc/en-us/articles/115004511086/:path*",
+      "source": "/hc/en-us/articles/115004511086*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115004511246/:path*",
+      "source": "/hc/en-us/articles/115004511246*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115004511803/:path*",
+      "source": "/hc/en-us/articles/115004511803*",
       "destination": "/docs/users#faq"
     },
     {
-      "source": "/hc/en-us/articles/115004519886/:path*",
+      "source": "/hc/en-us/articles/115004519886*",
       "destination": "/docs/best-practices/create-a-tracking-plan"
     },
     {
-      "source": "/hc/en-us/articles/115004545983/:path*",
+      "source": "/hc/en-us/articles/115004545983*",
       "destination": "/docs/data-structure/events-and-properties"
     },
     {
-      "source": "/hc/en-us/articles/115004546843/:path*",
+      "source": "/hc/en-us/articles/115004546843*",
       "destination": "/docs/tracking-methods/integrations/cms-ecommerce"
     },
     {
-      "source": "/hc/en-us/articles/115004546863/:path*",
+      "source": "/hc/en-us/articles/115004546863*",
       "destination": "/docs/quickstart/install-mixpanel"
     },
     {
-      "source": "/hc/en-us/articles/115004546883/:path*",
+      "source": "/hc/en-us/articles/115004546883*",
       "destination": "/docs/reports/retention#overview"
     },
     {
-      "source": "/hc/en-us/articles/115004547063/:path*",
+      "source": "/hc/en-us/articles/115004547063*",
       "destination": "/docs/how-it-works/concepts#supported-data-types"
     },
     {
-      "source": "/hc/en-us/articles/115004547203/:path*",
+      "source": "/hc/en-us/articles/115004547203*",
       "destination": "/docs/orgs-and-projects/managing-projects#manage-timezones-for-projects"
     },
     {
-      "source": "/hc/en-us/articles/115004547263/:path*",
+      "source": "/hc/en-us/articles/115004547263*",
       "destination": "/docs/data-structure/user-profiles#faq"
     },
     {
-      "source": "/hc/en-us/articles/115004551583/:path*",
+      "source": "/hc/en-us/articles/115004551583*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115004560686/:path*",
+      "source": "/hc/en-us/articles/115004560686*",
       "destination": "https://mixpanel.com/blog/the-death-of-the-pageview/"
     },
     {
-      "source": "/hc/en-us/articles/115004560846/:path*",
+      "source": "/hc/en-us/articles/115004560846*",
       "destination": "/docs/tracking-methods/integrations/segment"
     },
     {
-      "source": "/hc/en-us/articles/115004561766/:path*",
+      "source": "/hc/en-us/articles/115004561766*",
       "destination": "/docs/tracking/how-tos/utm"
     },
     {
-      "source": "/hc/en-us/articles/115004561786/:path*",
+      "source": "/hc/en-us/articles/115004561786*",
       "destination": "/docs/tracking/how-tos/utm"
     },
     {
-      "source": "/hc/en-us/articles/115004561926/:path*",
+      "source": "/hc/en-us/articles/115004561926*",
       "destination": "/docs/reports/funnels"
     },
     {
-      "source": "/hc/en-us/articles/115004562246/:path*",
+      "source": "/hc/en-us/articles/115004562246*",
       "destination": "/docs/features/custom-events"
     },
     {
-      "source": "/hc/en-us/articles/115004562723/:path*",
+      "source": "/hc/en-us/articles/115004562723*",
       "destination": "/docs/export-methods"
     },
     {
-      "source": "/hc/en-us/articles/115004565746/:path*",
+      "source": "/hc/en-us/articles/115004565746*",
       "destination": "/docs/boards"
     },
     {
-      "source": "/hc/en-us/articles/115004565766/:path*",
+      "source": "/hc/en-us/articles/115004565766*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115004565806/:path*",
+      "source": "/hc/en-us/articles/115004565806*",
       "destination": "/docs/data-structure/user-profiles#deleting-user-profiles"
     },
     {
-      "source": "/hc/en-us/articles/115004567503/:path*",
+      "source": "/hc/en-us/articles/115004567503*",
       "destination": "/docs/reports/apps/signal"
     },
     {
-      "source": "/hc/en-us/articles/115004567926/:path*",
+      "source": "/hc/en-us/articles/115004567926*",
       "destination": "/docs/data-governance/lexicon#hide-events-and-properties"
     },
     {
-      "source": "/hc/en-us/articles/115004569183/:path*",
+      "source": "/hc/en-us/articles/115004569183*",
       "destination": "/docs/data-governance/lexicon"
     },
     {
-      "source": "/hc/en-us/articles/115004581743/:path*",
+      "source": "/hc/en-us/articles/115004581743*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115004581763/:path*",
+      "source": "/hc/en-us/articles/115004581763*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115004596186/:path*",
+      "source": "/hc/en-us/articles/115004596186*",
       "destination": "/docs/tracking-methods/sdks/android#legacy-automatically-tracked-events"
     },
     {
-      "source": "/hc/en-us/articles/115004600343/:path*",
+      "source": "/hc/en-us/articles/115004600343*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115004600723/:path*",
+      "source": "/hc/en-us/articles/115004600723*",
       "destination": "/docs/data-structure/advanced/utm-tags#mobile-attribution"
     },
     {
-      "source": "/hc/en-us/articles/115004600763/:path*",
+      "source": "/hc/en-us/articles/115004600763*",
       "destination": "/docs/features/custom-events"
     },
     {
-      "source": "/hc/en-us/articles/115004602503/:path*",
+      "source": "/hc/en-us/articles/115004602503*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115004602543/:path*",
+      "source": "/hc/en-us/articles/115004602543*",
       "destination": "/docs/tracking-methods/sdks/android"
     },
     {
-      "source": "/hc/en-us/articles/115004602563/:path*",
+      "source": "/hc/en-us/articles/115004602563*",
       "destination": "https://developer.mixpanel.com/reference/raw-event-export"
     },
     {
-      "source": "/hc/en-us/articles/115004613766/:path*",
+      "source": "/hc/en-us/articles/115004613766*",
       "destination": "/docs/data-structure/property-reference"
     },
     {
-      "source": "/hc/en-us/articles/115004615466/:path*",
+      "source": "/hc/en-us/articles/115004615466*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115004615526/:path*",
+      "source": "/hc/en-us/articles/115004615526*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115004616406/:path*",
+      "source": "/hc/en-us/articles/115004616406*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115004616486/:path*",
+      "source": "/hc/en-us/articles/115004616486*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115004617366/:path*",
+      "source": "/hc/en-us/articles/115004617366*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115004617706/:path*",
+      "source": "/hc/en-us/articles/115004617706*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115004695223/:path*",
+      "source": "/hc/en-us/articles/115004695223*",
       "destination": "/docs/features/sessions"
     },
     {
-      "source": "/hc/en-us/articles/115004695283/:path*",
+      "source": "/hc/en-us/articles/115004695283*",
       "destination": "/docs/tracking-methods/sdks/ios#tracking-revenue"
     },
     {
-      "source": "/hc/en-us/articles/115004695323/:path*",
+      "source": "/hc/en-us/articles/115004695323*",
       "destination": "/docs/users#advanced"
     },
     {
-      "source": "/hc/en-us/articles/115004708186/:path*",
+      "source": "/hc/en-us/articles/115004708186*",
       "destination": "/docs/data-structure/user-profiles"
     },
     {
-      "source": "/hc/en-us/articles/115004723526/:path*",
+      "source": "/hc/en-us/articles/115004723526*",
       "destination": "/docs/what-to-track"
     },
     {
-      "source": "/hc/en-us/articles/115004723646/:path*",
+      "source": "/hc/en-us/articles/115004723646*",
       "destination": "/docs/data-structure/user-profiles"
     },
     {
-      "source": "/hc/en-us/articles/115004734463/:path*",
+      "source": "/hc/en-us/articles/115004734463*",
       "destination": "/docs/quickstart/track-events#http-api"
     },
     {
-      "source": "/hc/en-us/articles/115004958823/:path*",
+      "source": "/hc/en-us/articles/115004958823*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115005524446/:path*",
+      "source": "/hc/en-us/articles/115005524446*",
       "destination": "/docs/what-is-mixpanel"
     },
     {
-      "source": "/hc/en-us/articles/115005641266/:path*",
+      "source": "/hc/en-us/articles/115005641266*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115005664806/:path*",
+      "source": "/hc/en-us/articles/115005664806*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/115005701343/:path*",
+      "source": "/hc/en-us/articles/115005701343*",
       "destination": "/docs/users/cohorts#creating-cohorts"
     },
     {
-      "source": "/hc/en-us/articles/115005708186/:path*",
+      "source": "/hc/en-us/articles/115005708186*",
       "destination": "/docs/users/cohorts"
     },
     {
-      "source": "/hc/en-us/articles/115005712363/:path*",
+      "source": "/hc/en-us/articles/115005712363*",
       "destination": "/docs/cohort-sync/integrations/airship"
     },
     {
-      "source": "/hc/en-us/articles/115005719646/:path*",
+      "source": "/hc/en-us/articles/115005719646*",
       "destination": "/docs/cohort-sync/integrations/marketo"
     },
     {
-      "source": "/hc/en-us/articles/12538250505236/:path*",
+      "source": "/hc/en-us/articles/12538250505236*",
       "destination": "/docs/features/embeds"
     },
     {
-      "source": "/hc/en-us/articles/13174988269844/:path*",
+      "source": "/hc/en-us/articles/13174988269844*",
       "destination": "/changelogs/2022-12-01-improvements"
     },
     {
-      "source": "/hc/en-us/articles/13175102961428/:path*",
+      "source": "/hc/en-us/articles/13175102961428*",
       "destination": "/changelogs/2022-12-13-boards"
     },
     {
-      "source": "/hc/en-us/articles/13175146659732/:path*",
+      "source": "/hc/en-us/articles/13175146659732*",
       "destination": "/changelogs/2023-01-18-table-boards"
     },
     {
-      "source": "/hc/en-us/articles/13175184938260/:path*",
+      "source": "/hc/en-us/articles/13175184938260*",
       "destination": "/changelogs/2023-01-23-users-flows"
     },
     {
-      "source": "/hc/en-us/articles/13175224500628/:path*",
+      "source": "/hc/en-us/articles/13175224500628*",
       "destination": "/changelogs/2023-01-31-embed"
     },
     {
-      "source": "/hc/en-us/articles/13271005313556/:path*",
+      "source": "/hc/en-us/articles/13271005313556*",
       "destination": "/docs/reports/insights#table-chart"
     },
     {
-      "source": "/hc/en-us/articles/13395179786644/:path*",
+      "source": "/hc/en-us/articles/13395179786644*",
       "destination": "/changelogs/2022-07-08-reorient"
     },
     {
-      "source": "/hc/en-us/articles/13395198918804/:path*",
+      "source": "/hc/en-us/articles/13395198918804*",
       "destination": "/changelogs/2022-11-03-session-improvements"
     },
     {
-      "source": "/hc/en-us/articles/13395199893652/:path*",
+      "source": "/hc/en-us/articles/13395199893652*",
       "destination": "/changelogs/2022-11-07-millisecond"
     },
     {
-      "source": "/hc/en-us/articles/13395205961236/:path*",
+      "source": "/hc/en-us/articles/13395205961236*",
       "destination": "/changelogs/2022-07-01-view-users"
     },
     {
-      "source": "/hc/en-us/articles/13395233184916/:path*",
+      "source": "/hc/en-us/articles/13395233184916*",
       "destination": "/changelogs/2022-06-16-faster-workflow"
     },
     {
-      "source": "/hc/en-us/articles/13395235568660/:path*",
+      "source": "/hc/en-us/articles/13395235568660*",
       "destination": "/changelogs/2022-05-31-improve-conversion-flow"
     },
     {
-      "source": "/hc/en-us/articles/13395324158868/:path*",
+      "source": "/hc/en-us/articles/13395324158868*",
       "destination": "/changelogs/2022-05-24-lexicon-context"
     },
     {
-      "source": "/hc/en-us/articles/13395325754772/:path*",
+      "source": "/hc/en-us/articles/13395325754772*",
       "destination": "/changelogs/2022-04-18-relative-comparison"
     },
     {
-      "source": "/hc/en-us/articles/13395328448404/:path*",
+      "source": "/hc/en-us/articles/13395328448404*",
       "destination": "/changelogs/2022-03-29-text-boards"
     },
     {
-      "source": "/hc/en-us/articles/13530857626132/:path*",
+      "source": "/hc/en-us/articles/13530857626132*",
       "destination": "/docs/pricing"
     },
     {
-      "source": "/hc/en-us/articles/13756463065492/:path*",
+      "source": "/hc/en-us/articles/13756463065492*",
       "destination": "/changelogs/2023-02-28-retention-calendar-interval"
     },
     {
-      "source": "/hc/en-us/articles/14202292561172/:path*",
+      "source": "/hc/en-us/articles/14202292561172*",
       "destination": "/docs/features/embeds"
     },
     {
-      "source": "/hc/en-us/articles/14377628688788/:path*",
+      "source": "/hc/en-us/articles/14377628688788*",
       "destination": "/docs/tracking-methods/id-management/identifying-users"
     },
     {
-      "source": "/hc/en-us/articles/14383975110292/:path*",
+      "source": "/hc/en-us/articles/14383975110292*",
       "destination": "/docs/tracking-methods/id-management/identifying-users"
     },
     {
-      "source": "/hc/en-us/articles/15219555384468/:path*",
+      "source": "/hc/en-us/articles/15219555384468*",
       "destination": "/docs/boards/templates"
     },
     {
-      "source": "/hc/en-us/articles/15235786397716/:path*",
+      "source": "/hc/en-us/articles/15235786397716*",
       "destination": "/docs/data-structure/advanced/ad-spend#gathering-data-from-ad-networks"
     },
     {
-      "source": "/hc/en-us/articles/15266196509972/:path*",
+      "source": "/hc/en-us/articles/15266196509972*",
       "destination": "https://github.com/mixpanel/sheets#readme"
     },
     {
-      "source": "/hc/en-us/articles/15271983688212/:path*",
+      "source": "/hc/en-us/articles/15271983688212*",
       "destination": "/docs/features/attribution#overview"
     },
     {
-      "source": "/hc/en-us/articles/15418504274580/:path*",
+      "source": "/hc/en-us/articles/15418504274580*",
       "destination": "/docs/features/alerts"
     },
     {
-      "source": "/hc/en-us/articles/15470725656340/:path*",
+      "source": "/hc/en-us/articles/15470725656340*",
       "destination": "/docs/migration/google-analytics"
     },
     {
-      "source": "/hc/en-us/articles/360000345423/:path*",
+      "source": "/hc/en-us/articles/360000345423*",
       "destination": "/docs/privacy/gdpr-compliance"
     },
     {
-      "source": "/hc/en-us/articles/360000664223/:path*",
+      "source": "/hc/en-us/articles/360000664223*",
       "destination": "/docs/pricing#downgrade-your-plan"
     },
     {
-      "source": "/hc/en-us/articles/360000679006/:path*",
+      "source": "/hc/en-us/articles/360000679006*",
       "destination": "/docs/privacy/protecting-user-data"
     },
     {
-      "source": "/hc/en-us/articles/360000791746/:path*",
+      "source": "/hc/en-us/articles/360000791746*",
       "destination": "/docs/privacy/protecting-user-data"
     },
     {
-      "source": "/hc/en-us/articles/360000857366/:path*",
+      "source": "/hc/en-us/articles/360000857366*",
       "destination": "/docs/how-it-works/concepts"
     },
     {
-      "source": "/hc/en-us/articles/360000865566/:path*",
+      "source": "/hc/en-us/articles/360000865566*",
       "destination": "/docs/how-it-works/concepts"
     },
     {
-      "source": "/hc/en-us/articles/360000881023/:path*",
+      "source": "/hc/en-us/articles/360000881023*",
       "destination": "/docs/privacy/end-user-data-management"
     },
     {
-      "source": "/hc/en-us/articles/360000894623/:path*",
+      "source": "/hc/en-us/articles/360000894623*",
       "destination": "/docs/how-it-works/concepts"
     },
     {
-      "source": "/hc/en-us/articles/360000902886/:path*",
+      "source": "/hc/en-us/articles/360000902886*",
       "destination": "/docs/users"
     },
     {
-      "source": "/hc/en-us/articles/360000953003/:path*",
+      "source": "/hc/en-us/articles/360000953003*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/360001113426/:path*",
+      "source": "/hc/en-us/articles/360001113426*",
       "destination": "/docs/privacy/protecting-user-data"
     },
     {
-      "source": "/hc/en-us/articles/360001131323/:path*",
+      "source": "/hc/en-us/articles/360001131323*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/360001182866/:path*",
+      "source": "/hc/en-us/articles/360001182866*",
       "destination": "/docs/reports"
     },
     {
-      "source": "/hc/en-us/articles/360001236083/:path*",
+      "source": "/hc/en-us/articles/360001236083*",
       "destination": "/docs/features/custom-buckets"
     },
     {
-      "source": "/hc/en-us/articles/360001243663/:path*",
+      "source": "/hc/en-us/articles/360001243663*",
       "destination": "/docs/cohort-sync/integrations/braze"
     },
     {
-      "source": "/hc/en-us/articles/360001307806/:path*",
+      "source": "/hc/en-us/articles/360001307806*",
       "destination": "/docs/data-governance/lexicon"
     },
     {
-      "source": "/hc/en-us/articles/360001321243/:path*",
+      "source": "/hc/en-us/articles/360001321243*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/360001333826/:path*",
+      "source": "/hc/en-us/articles/360001333826*",
       "destination": "/docs/reports/insights"
     },
     {
-      "source": "/hc/en-us/articles/360001337043/:path*",
+      "source": "/hc/en-us/articles/360001337043*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/360001337103/:path*",
+      "source": "/hc/en-us/articles/360001337103*",
       "destination": "/docs/tracking/how-tos/utm"
     },
     {
-      "source": "/hc/en-us/articles/360001354886/:path*",
+      "source": "/hc/en-us/articles/360001354886*",
       "destination": "/docs/best-practices/developer-environments#separate-development-data"
     },
     {
-      "source": "/hc/en-us/articles/360001355146/:path*",
+      "source": "/hc/en-us/articles/360001355146*",
       "destination": "/docs/best-practices/server-side-best-practices#tracking-browser-device-and-os"
     },
     {
-      "source": "/hc/en-us/articles/360001355166/:path*",
+      "source": "/hc/en-us/articles/360001355166*",
       "destination": "/docs/tracking-methods/integrations/google-tag-manager"
     },
     {
-      "source": "/hc/en-us/articles/360001355206/:path*",
+      "source": "/hc/en-us/articles/360001355206*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/360001355266/:path*",
+      "source": "/hc/en-us/articles/360001355266*",
       "destination": "/docs/data-structure/events-and-properties"
     },
     {
-      "source": "/hc/en-us/articles/360001355466/:path*",
+      "source": "/hc/en-us/articles/360001355466*",
       "destination": "/docs/best-practices/server-side-best-practices#identifying-users"
     },
     {
-      "source": "/hc/en-us/articles/360001355506/:path*",
+      "source": "/hc/en-us/articles/360001355506*",
       "destination": "/docs/reports#first-time-ever-filter"
     },
     {
-      "source": "/hc/en-us/articles/360001359106/:path*",
+      "source": "/hc/en-us/articles/360001359106*",
       "destination": "/docs/pricing#sales-tax"
     },
     {
-      "source": "/hc/en-us/articles/360001360643/:path*",
+      "source": "/hc/en-us/articles/360001360643*",
       "destination": "/docs/features/advanced#top-segments-logic"
     },
     {
-      "source": "/hc/en-us/articles/360001361023/:path*",
+      "source": "/hc/en-us/articles/360001361023*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/360001370146/:path*",
+      "source": "/hc/en-us/articles/360001370146*",
       "destination": "/docs/reports/retention"
     },
     {
-      "source": "/hc/en-us/articles/360001386926/:path*",
+      "source": "/hc/en-us/articles/360001386926*",
       "destination": "/docs/reports/flows"
     },
     {
-      "source": "/hc/en-us/articles/360001465686/:path*",
+      "source": "/hc/en-us/articles/360001465686*",
       "destination": "/docs/pricing#mtu-pricing-reference"
     },
     {
-      "source": "/hc/en-us/articles/360019982652/:path*",
+      "source": "/hc/en-us/articles/360019982652*",
       "destination": "/docs/reports/funnels"
     },
     {
-      "source": "/hc/en-us/articles/360020281651/:path*",
+      "source": "/hc/en-us/articles/360020281651*",
       "destination": "/docs/response-times"
     },
     {
-      "source": "/hc/en-us/articles/360020461952/:path*",
+      "source": "/hc/en-us/articles/360020461952*",
       "destination": "/docs/admin/organizations-projects"
     },
     {
-      "source": "/hc/en-us/articles/360020731811/:path*",
+      "source": "/hc/en-us/articles/360020731811*",
       "destination": "/docs/orgs-and-projects/roles-and-permissions"
     },
     {
-      "source": "/hc/en-us/articles/360020731831/:path*",
+      "source": "/hc/en-us/articles/360020731831*",
       "destination": "/docs/orgs-and-projects/roles-and-permissions#teams"
     },
     {
-      "source": "/hc/en-us/articles/360021085271/:path*",
+      "source": "/hc/en-us/articles/360021085271*",
       "destination": "/docs/admin/organizations-projects"
     },
     {
-      "source": "/hc/en-us/articles/360021115871/:path*",
+      "source": "/hc/en-us/articles/360021115871*",
       "destination": "/docs/data-structure/user-profiles#faq"
     },
     {
-      "source": "/hc/en-us/articles/360021748752/:path*",
+      "source": "/hc/en-us/articles/360021748752*",
       "destination": "/docs/reports/retention"
     },
     {
-      "source": "/hc/en-us/articles/360021749032/:path*",
+      "source": "/hc/en-us/articles/360021749032*",
       "destination": "/docs/reports/retention"
     },
     {
-      "source": "/hc/en-us/articles/360021916032/:path*",
+      "source": "/hc/en-us/articles/360021916032*",
       "destination": "/docs/how-it-works/concepts"
     },
     {
-      "source": "/hc/en-us/articles/360022537091/:path*",
+      "source": "/hc/en-us/articles/360022537091*",
       "destination": "/docs/reports/retention"
     },
     {
-      "source": "/hc/en-us/articles/360024613412/:path*",
+      "source": "/hc/en-us/articles/360024613412*",
       "destination": "/docs/orgs-and-projects/roles-and-permissions#project-roles"
     },
     {
-      "source": "/hc/en-us/articles/360024815311/:path*",
+      "source": "/hc/en-us/articles/360024815311*",
       "destination": "/docs/orgs-and-projects/managing-projects#transfer-project-to-another-organization"
     },
     {
-      "source": "/hc/en-us/articles/360024910951/:path*",
+      "source": "/hc/en-us/articles/360024910951*",
       "destination": "/docs/admin/organizations-projects"
     },
     {
-      "source": "/hc/en-us/articles/360025333632/:path*",
+      "source": "/hc/en-us/articles/360025333632*",
       "destination": "/docs/data-structure/advanced/group-analytics"
     },
     {
-      "source": "/hc/en-us/articles/360025344831/:path*",
+      "source": "/hc/en-us/articles/360025344831*",
       "destination": "/docs/reports/funnels#how-does-mixpanel-handle-simultaneous-events"
     },
     {
-      "source": "/hc/en-us/articles/360025387911/:path*",
+      "source": "/hc/en-us/articles/360025387911*",
       "destination": "/docs/orgs-and-projects/roles-and-permissions#organization-roles"
     },
     {
-      "source": "/hc/en-us/articles/360025670271/:path*",
+      "source": "/hc/en-us/articles/360025670271*",
       "destination": "/docs/users/cohorts#creating-a-cohort-via-a-report"
     },
     {
-      "source": "/hc/en-us/articles/360027359672/:path*",
+      "source": "/hc/en-us/articles/360027359672*",
       "destination": "/docs/reports/insights"
     },
     {
-      "source": "/hc/en-us/articles/360027754631/:path*",
+      "source": "/hc/en-us/articles/360027754631*",
       "destination": "/docs/features/advanced#query-result-caching"
     },
     {
-      "source": "/hc/en-us/articles/360028142571/:path*",
+      "source": "/hc/en-us/articles/360028142571*",
       "destination": "/docs/features/alerts"
     },
     {
-      "source": "/hc/en-us/articles/360028380611/:path*",
+      "source": "/hc/en-us/articles/360028380611*",
       "destination": "/docs/how-it-works/concepts"
     },
     {
-      "source": "/hc/en-us/articles/360028823552/:path*",
+      "source": "/hc/en-us/articles/360028823552*",
       "destination": "/docs/data-governance/data-views-and-classification"
     },
     {
-      "source": "/hc/en-us/articles/360029126351/:path*",
+      "source": "/hc/en-us/articles/360029126351*",
       "destination": "/docs/reports#query-time-sampling"
     },
     {
-      "source": "/hc/en-us/articles/360029190092/:path*",
+      "source": "/hc/en-us/articles/360029190092*",
       "destination": "/docs/reports/funnels#advanced"
     },
     {
-      "source": "/hc/en-us/articles/360030848432/:path*",
+      "source": "/hc/en-us/articles/360030848432*",
       "destination": "/docs/features/custom-properties"
     },
     {
-      "source": "/hc/en-us/articles/360031037172/:path*",
+      "source": "/hc/en-us/articles/360031037172*",
       "destination": "/docs/orgs-and-projects/roles-and-permissions#admin"
     },
     {
-      "source": "/hc/en-us/articles/360031788492/:path*",
+      "source": "/hc/en-us/articles/360031788492*",
       "destination": "/docs/reports#find-interesting-segments"
     },
     {
-      "source": "/hc/en-us/articles/360033248932/:path*",
+      "source": "/hc/en-us/articles/360033248932*",
       "destination": "/docs/data-structure/events-and-properties"
     },
     {
-      "source": "/hc/en-us/articles/360034129112/:path*",
+      "source": "/hc/en-us/articles/360034129112*",
       "destination": "/docs/reports/apps/impact"
     },
     {
-      "source": "/hc/en-us/articles/360035109991/:path*",
+      "source": "/hc/en-us/articles/360035109991*",
       "destination": "/docs/best-practices/create-a-tracking-plan"
     },
     {
-      "source": "/hc/en-us/articles/360035583452/:path*",
+      "source": "/hc/en-us/articles/360035583452*",
       "destination": "/docs/cohort-sync/integrations/facebook-ads"
     },
     {
-      "source": "/hc/en-us/articles/360036428871/:path*",
+      "source": "/hc/en-us/articles/360036428871*",
       "destination": "/docs/access-security/single-sign-on"
     },
     {
-      "source": "/hc/en-us/articles/360036438351/:path*",
+      "source": "/hc/en-us/articles/360036438351*",
       "destination": "/docs/reports/flows"
     },
     {
-      "source": "/hc/en-us/articles/360038439952/:path*",
+      "source": "/hc/en-us/articles/360038439952*",
       "destination": "/docs/experiments"
     },
     {
-      "source": "/hc/en-us/articles/360039133851/:path*",
+      "source": "/hc/en-us/articles/360039133851*",
       "destination": "/docs/tracking-methods/id-management/identifying-users"
     },
     {
-      "source": "/hc/en-us/articles/360039135652/:path*",
+      "source": "/hc/en-us/articles/360039135652*",
       "destination": "/docs/privacy/eu-residency"
     },
     {
-      "source": "/hc/en-us/articles/360039256492/:path*",
+      "source": "/hc/en-us/articles/360039256492*",
       "destination": "/docs/cohort-sync/integrations/google-ads"
     },
     {
-      "source": "/hc/en-us/articles/360039403631/:path*",
+      "source": "/hc/en-us/articles/360039403631*",
       "destination": "/docs/cohort-sync/integrations/iterable"
     },
     {
-      "source": "/hc/en-us/articles/360040323292/:path*",
+      "source": "/hc/en-us/articles/360040323292*",
       "destination": "/docs/orgs-and-projects/organizations#sso-via-microsoft-azure"
     },
     {
-      "source": "/hc/en-us/articles/360041039771/:path*",
+      "source": "/hc/en-us/articles/360041039771*",
       "destination": "/docs/tracking-methods/id-management/identifying-users"
     },
     {
-      "source": "/hc/en-us/articles/360041693771/:path*",
+      "source": "/hc/en-us/articles/360041693771*",
       "destination": "/docs/data-structure/user-profiles"
     },
     {
-      "source": "/hc/en-us/articles/360041989072/:path*",
+      "source": "/hc/en-us/articles/360041989072*",
       "destination": "/docs/what-is-mixpanel"
     },
     {
-      "source": "/hc/en-us/articles/360041995352/:path*",
+      "source": "/hc/en-us/articles/360041995352*",
       "destination": "/docs/tracking/how-tos/events-properties"
     },
     {
-      "source": "/hc/en-us/articles/360042412051/:path*",
+      "source": "/hc/en-us/articles/360042412051*",
       "destination": "/docs/what-is-mixpanel"
     },
     {
-      "source": "/hc/en-us/articles/360043474691/:path*",
+      "source": "/hc/en-us/articles/360043474691*",
       "destination": "/docs/pricing/startup-program"
     },
     {
-      "source": "/hc/en-us/articles/360043776692/:path*",
+      "source": "/hc/en-us/articles/360043776692*",
       "destination": "/docs/features/slack-integration"
     },
     {
-      "source": "/hc/en-us/articles/360043782572/:path*",
+      "source": "/hc/en-us/articles/360043782572*",
       "destination": "/docs/data-governance/data-views-and-classification#manage-data-view"
     },
     {
-      "source": "/hc/en-us/articles/360043837132/:path*",
+      "source": "/hc/en-us/articles/360043837132*",
       "destination": "/docs/data-governance/data-views-and-classification#use-cases"
     },
     {
-      "source": "/hc/en-us/articles/360044139291/:path*",
+      "source": "/hc/en-us/articles/360044139291*",
       "destination": "/docs/data-structure/lookup-tables"
     },
     {
-      "source": "/hc/en-us/articles/360044295131/:path*",
+      "source": "/hc/en-us/articles/360044295131*",
       "destination": "/docs/data-governance/data-views-and-classification#data-classification"
     },
     {
-      "source": "/hc/en-us/articles/360044299311/:path*",
+      "source": "/hc/en-us/articles/360044299311*",
       "destination": "/docs/orgs-and-projects/roles-and-permissions#permissions"
     },
     {
-      "source": "/hc/en-us/articles/360045484191/:path*",
+      "source": "/hc/en-us/articles/360045484191*",
       "destination": "/docs/reports/retention#advanced"
     },
     {
-      "source": "/hc/en-us/articles/360047094171/:path*",
+      "source": "/hc/en-us/articles/360047094171*",
       "destination": "/docs/features/advanced#list-property-support"
     },
     {
-      "source": "/hc/en-us/articles/360048486671/:path*",
+      "source": "/hc/en-us/articles/360048486671*",
       "destination": "/docs/debugging/overview#inactive-events-and-properties"
     },
     {
-      "source": "/hc/en-us/articles/360049332572/:path*",
+      "source": "/hc/en-us/articles/360049332572*",
       "destination": "/docs/cohort-sync/integrations/moengage"
     },
     {
-      "source": "/hc/en-us/articles/360049450392/:path*",
+      "source": "/hc/en-us/articles/360049450392*",
       "destination": "/docs/reports"
     },
     {
-      "source": "/hc/en-us/articles/360050608232/:path*",
+      "source": "/hc/en-us/articles/360050608232*",
       "destination": "/docs/cohort-sync/integrations/chameleon"
     },
     {
-      "source": "/hc/en-us/articles/360050702631/:path*",
+      "source": "/hc/en-us/articles/360050702631*",
       "destination": "/docs/cohort-sync/integrations/leanplum"
     },
     {
-      "source": "/hc/en-us/articles/360051018011/:path*",
+      "source": "/hc/en-us/articles/360051018011*",
       "destination": "/docs/cohort-sync/integrations/onesignal"
     },
     {
-      "source": "/hc/en-us/articles/360051314911/:path*",
+      "source": "/hc/en-us/articles/360051314911*",
       "destination": "/docs/cohort-sync/integrations/appcues"
     },
     {
-      "source": "/hc/en-us/articles/360051368091/:path*",
+      "source": "/hc/en-us/articles/360051368091*",
       "destination": "/docs/cohort-sync/integrations/insider"
     },
     {
-      "source": "/hc/en-us/articles/360055654412/:path*",
+      "source": "/hc/en-us/articles/360055654412*",
       "destination": "/docs/cohort-sync/integrations/vwo"
     },
     {
-      "source": "/hc/en-us/articles/360055834811/:path*",
+      "source": "/hc/en-us/articles/360055834811*",
       "destination": "/docs/cohort-sync/integrations/kameleoon"
     },
     {
-      "source": "/hc/en-us/articles/360056090251/:path*",
+      "source": "/hc/en-us/articles/360056090251*",
       "destination": "/docs/cohort-sync/integrations/taplytics"
     },
     {
-      "source": "/hc/en-us/articles/360057106912/:path*",
+      "source": "/hc/en-us/articles/360057106912*",
       "destination": "/docs/cohort-sync/integrations/mailchimp"
     },
     {
-      "source": "/hc/en-us/articles/360057520772/:path*",
+      "source": "/hc/en-us/articles/360057520772*",
       "destination": "/docs/reports/funnels#conversion--dropoff-flows"
     },
     {
-      "source": "/hc/en-us/articles/360059064332/:path*",
+      "source": "/hc/en-us/articles/360059064332*",
       "destination": "/docs/cohort-sync/integrations/xtremepush"
     },
     {
-      "source": "/hc/en-us/articles/360060422811/:path*",
+      "source": "/hc/en-us/articles/360060422811*",
       "destination": "/docs/reports/retention#faq"
     },
     {
-      "source": "/hc/en-us/articles/360061162352/:path*",
+      "source": "/hc/en-us/articles/360061162352*",
       "destination": "/docs/cohort-sync/integrations/webengage"
     },
     {
-      "source": "/hc/en-us/articles/360061218812/:path*",
+      "source": "/hc/en-us/articles/360061218812*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/articles/4402022733844/:path*",
+      "source": "/hc/en-us/articles/4402022733844*",
       "destination": "/docs/boards/public-boards"
     },
     {
-      "source": "/hc/en-us/articles/4402023147540/:path*",
+      "source": "/hc/en-us/articles/4402023147540*",
       "destination": "/docs/users"
     },
     {
-      "source": "/hc/en-us/articles/4402828400020/:path*",
+      "source": "/hc/en-us/articles/4402828400020*",
       "destination": "/docs/features/advanced#limits-and-ordering"
     },
     {
-      "source": "/hc/en-us/articles/4402837164948/:path*",
+      "source": "/hc/en-us/articles/4402837164948*",
       "destination": "/docs/debugging/overview"
     },
     {
-      "source": "/hc/en-us/articles/4405461037716/:path*",
+      "source": "/hc/en-us/articles/4405461037716*",
       "destination": "/docs/data-governance/lexicon#export-and-import-lexicon-data"
     },
     {
-      "source": "/hc/en-us/articles/4405768833684/:path*",
+      "source": "/hc/en-us/articles/4405768833684*",
       "destination": "/docs/cohort-sync/integrations/apptimize"
     },
     {
-      "source": "/hc/en-us/articles/4408079980948/:path*",
+      "source": "/hc/en-us/articles/4408079980948*",
       "destination": "/docs/cohort-sync"
     },
     {
-      "source": "/hc/en-us/articles/4408988683156/:path*",
+      "source": "/hc/en-us/articles/4408988683156*",
       "destination": "/docs/cohort-sync/integrations/segment"
     },
     {
-      "source": "/hc/en-us/articles/4409841288724/:path*",
+      "source": "/hc/en-us/articles/4409841288724*",
       "destination": "/docs/boards/advanced#faq"
     },
     {
-      "source": "/hc/en-us/articles/4409850288276/:path*",
+      "source": "/hc/en-us/articles/4409850288276*",
       "destination": "/docs/boards/advanced"
     },
     {
-      "source": "/hc/en-us/articles/4413141791764/:path*",
+      "source": "/hc/en-us/articles/4413141791764*",
       "destination": "/docs/reports/flows#advanced"
     },
     {
-      "source": "/hc/en-us/articles/4415881598996/:path*",
+      "source": "/hc/en-us/articles/4415881598996*",
       "destination": "/docs/cohort-sync/integrations/salesforce-marketing-cloud"
     },
     {
-      "source": "/hc/en-us/articles/4485419360916/:path*",
+      "source": "/hc/en-us/articles/4485419360916*",
       "destination": "/docs/reports#comparisons"
     },
     {
-      "source": "/hc/en-us/articles/4870177097748/:path*",
+      "source": "/hc/en-us/articles/4870177097748*",
       "destination": "https://github.com/mixpanel/mixpanel-gtm-template#readme"
     },
     {
-      "source": "/hc/en-us/articles/5556776427156/:path*",
+      "source": "/hc/en-us/articles/5556776427156*",
       "destination": "/docs/cohort-sync"
     },
     {
-      "source": "/hc/en-us/articles/6739032703508/:path*",
+      "source": "/hc/en-us/articles/6739032703508*",
       "destination": "/docs/boards/templates"
     },
     {
-      "source": "/hc/en-us/articles/6861234702484/:path*",
+      "source": "/hc/en-us/articles/6861234702484*",
       "destination": "/docs/orgs-and-projects/organizations#organization-discoverability"
     },
     {
-      "source": "/hc/en-us/articles/7001673006612/:path*",
+      "source": "/hc/en-us/articles/7001673006612*",
       "destination": "/docs/reports/insights#view-users"
     },
     {
-      "source": "/hc/en-us/articles/7079801425428/:path*",
+      "source": "/hc/en-us/articles/7079801425428*",
       "destination": "/docs/cohort-sync"
     },
     {
-      "source": "/hc/en-us/articles/7412632533524/:path*",
+      "source": "/hc/en-us/articles/7412632533524*",
       "destination": "/docs/boards#step-4-arrange-board-content"
     },
     {
-      "source": "/hc/en-us/articles/7646382971796/:path*",
+      "source": "/hc/en-us/articles/7646382971796*",
       "destination": "https://mixpanel.com/content/guide-to-product-analytics/chapter_3/"
     },
     {
-      "source": "/hc/en-us/articles/7647069378196/:path*",
+      "source": "/hc/en-us/articles/7647069378196*",
       "destination": "https://mixpanel.com/content/guide-to-product-analytics/chapter_4/"
     },
     {
-      "source": "/hc/en-us/articles/7647365321620/:path*",
+      "source": "/hc/en-us/articles/7647365321620*",
       "destination": "https://mixpanel.com/content/guide-to-product-analytics/chapter_5/"
     },
     {
-      "source": "/hc/en-us/articles/7651210894740/:path*",
+      "source": "/hc/en-us/articles/7651210894740*",
       "destination": "/docs/reports"
     },
     {
-      "source": "/hc/en-us/articles/7651639898260/:path*",
+      "source": "/hc/en-us/articles/7651639898260*",
       "destination": "/docs/reports"
     },
     {
-      "source": "/hc/en-us/articles/7713028610964/:path*",
+      "source": "/hc/en-us/articles/7713028610964*",
       "destination": "/docs/reports/insights#advanced"
     },
     {
-      "source": "/hc/en-us/articles/7715039510548/:path*",
+      "source": "/hc/en-us/articles/7715039510548*",
       "destination": "/docs/features/advanced#query-builder-features"
     },
     {
-      "source": "/hc/en-us/articles/7716920767124/:path*",
+      "source": "/hc/en-us/articles/7716920767124*",
       "destination": "/docs/reports/funnels#faq"
     },
     {
-      "source": "/hc/en-us/articles/7773849285780/:path*",
+      "source": "/hc/en-us/articles/7773849285780*",
       "destination": "/docs/data-structure/lookup-tables"
     },
     {
-      "source": "/hc/en-us/articles/9648680824852/:path*",
+      "source": "/hc/en-us/articles/9648680824852*",
       "destination": "/docs/tracking-methods/id-management/identifying-users"
     },
     {
-      "source": "/hc/en-us/articles/9671249667988/:path*",
+      "source": "/hc/en-us/articles/9671249667988*",
       "destination": "/docs/community/guidelines"
     },
     {
-      "source": "/hc/en-us/categories/115000963103/:path*",
+      "source": "/hc/en-us/categories/115000963103*",
       "destination": "/docs/admin/organizations-projects"
     },
     {
-      "source": "/hc/en-us/categories/115001031023/:path*",
+      "source": "/hc/en-us/categories/115001031023*",
       "destination": "/docs/how-it-works/concepts#overview"
     },
     {
-      "source": "/hc/en-us/categories/115001157746/:path*",
+      "source": "/hc/en-us/categories/115001157746*",
       "destination": "/docs/data-governance/lexicon"
     },
     {
-      "source": "/hc/en-us/categories/115001197206/:path*",
+      "source": "/hc/en-us/categories/115001197206*",
       "destination": "/docs/quickstart/install-mixpanel"
     },
     {
-      "source": "/hc/en-us/categories/115001197226/:path*",
+      "source": "/hc/en-us/categories/115001197226*",
       "destination": "/docs"
     },
     {
-      "source": "/hc/en-us/categories/115001197266/:path*",
+      "source": "/hc/en-us/categories/115001197266*",
       "destination": "/docs/what-is-mixpanel"
     },
     {
-      "source": "/hc/en-us/categories/115001209063/:path*",
+      "source": "/hc/en-us/categories/115001209063*",
       "destination": "/docs/boards"
     },
     {
-      "source": "/hc/en-us/categories/13174726206612/:path*",
+      "source": "/hc/en-us/categories/13174726206612*",
       "destination": "/changelogs"
     },
     {
@@ -2662,27 +2662,27 @@
       "destination": "/docs/what-is-mixpanel"
     },
     {
-      "source": "/hc/en-us/sections/115001299203/:path*",
+      "source": "/hc/en-us/sections/115001299203*",
       "destination": "/docs/tracking-methods/id-management/identifying-users"
     },
     {
-      "source": "/hc/en-us/sections/115001308546/:path*",
+      "source": "/hc/en-us/sections/115001308546*",
       "destination": "/docs/quickstart/track-events?sdk=httpapi"
     },
     {
-      "source": "/hc/en-us/sections/115001308566/:path*",
+      "source": "/hc/en-us/sections/115001308566*",
       "destination": "/docs/reports/apps/jql"
     },
     {
-      "source": "/hc/en-us/sections/115001517666/:path*",
+      "source": "/hc/en-us/sections/115001517666*",
       "destination": "/docs/cohort-sync"
     },
     {
-      "source": "/hc/en-us/sections/360006013852/:path*",
+      "source": "/hc/en-us/sections/360006013852*",
       "destination": "/docs/what-is-mixpanel"
     },
     {
-      "source": "/hc/en-us/sections/360008533532/:path*",
+      "source": "/hc/en-us/sections/360008533532*",
       "destination": "/docs/what-is-mixpanel"
     },
     {


### PR DESCRIPTION
Migrated `/hc/en-us/articles/<id>/:path*` redirects only matched a bare ID or `/id/subpath`, so canonical Zendesk URLs of the form `<id>-slug` (e.g. `360044139291-Lookup-tables`) fell through to 404. This converts all 262 `/hc/` article, category, and section redirect sources in `docs.json` from `/<ID>/:path*` to a slug-tolerant `<ID>*` splat (verified 0 ID prefix collisions, so no cross-article matches).

Linear link: https://linear.app/mixpanel/issue/TOF-290/

# Test / Rollout plan
- Slug form (the reported bug): visit `/hc/en-us/articles/360044139291-Lookup-tables` → should 308 to `/docs/data-structure/lookup-tables` (previously 404'd).
- Bare-ID form: visit `/hc/en-us/articles/360001370146` → should still redirect.
- Category/section: spot-check `/hc/en-us/categories/115001197206-Data-and-Implementation` and one `/hc/en-us/sections/<id>-...` URL redirect.
- Rollback: revert this commit; redirect sources return to the prior `/<ID>/:path*` form.