### PR TITLE
[TOF-323] Fix broken Feature Flags API reference docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1186,8 +1186,20 @@
             "group": "FEATURE FLAGS API",
             "pages": [
               "reference/feature-flags-api",
-              "reference/get-flag-definitions",
-              "reference/get-variant-assignments"
+              {
+                "group": "Get Flag Definitions",
+                "pages": [
+                  "reference/get-flag-definitions"
+                ],
+                "root": "reference/get-flag-definitions"
+              },
+              {
+                "group": "Get Variant Assignments",
+                "pages": [
+                  "reference/get-variant-assignments"
+                ],
+                "root": "reference/get-variant-assignments"
+              }
             ]
           },
           {

--- a/docs.json
+++ b/docs.json
@@ -1288,14 +1288,6 @@
   },
   "redirects": [
     {
-      "source": "/reference/get-flag-definitions-3",
-      "destination": "/reference/get-flag-definitions"
-    },
-    {
-      "source": "/reference/get-variant-assignments-3",
-      "destination": "/reference/get-variant-assignments"
-    },
-    {
       "source": "/changelogs/*",
       "destination": "/changelogs"
     },

--- a/docs.json
+++ b/docs.json
@@ -1186,20 +1186,8 @@
             "group": "FEATURE FLAGS API",
             "pages": [
               "reference/feature-flags-api",
-              {
-                "group": "Get Flag Definitions",
-                "pages": [
-                  "reference/get-flag-definitions-3"
-                ],
-                "root": "reference/get-flag-definitions"
-              },
-              {
-                "group": "Get Variant Assignments",
-                "pages": [
-                  "reference/get-variant-assignments-3"
-                ],
-                "root": "reference/get-variant-assignments"
-              }
+              "reference/get-flag-definitions",
+              "reference/get-variant-assignments"
             ]
           },
           {
@@ -1299,6 +1287,14 @@
     }
   },
   "redirects": [
+    {
+      "source": "/reference/get-flag-definitions-3",
+      "destination": "/reference/get-flag-definitions"
+    },
+    {
+      "source": "/reference/get-variant-assignments-3",
+      "destination": "/reference/get-variant-assignments"
+    },
     {
       "source": "/changelogs/*",
       "destination": "/changelogs"

--- a/openapi/feature-flags.openapi.yaml
+++ b/openapi/feature-flags.openapi.yaml
@@ -59,47 +59,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/EvaluateFlagsResponse'
         '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: Details about the error that occurred
-                  status:
-                    type: string
-                    enum:
-                      - error
+          $ref: '#/components/responses/BadRequest'
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: Details about the error that occurred
-                  status:
-                    type: string
-                    enum:
-                      - error
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: Details about the error that occurred
-                  status:
-                    type: string
-                    enum:
-                      - error
+          $ref: '#/components/responses/Forbidden'
   /flags/definitions:
     get:
       operationId: get-flag-definitions
@@ -121,33 +85,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/FlagDefinitionsResponse'
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: Details about the error that occurred
-                  status:
-                    type: string
-                    enum:
-                      - error
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: Details about the error that occurred
-                  status:
-                    type: string
-                    enum:
-                      - error
+          $ref: '#/components/responses/Forbidden'
 components:
   securitySchemes:
     ServiceAccount:
@@ -177,7 +117,38 @@ components:
         type: string
       description: The Mixpanel project_id. Provide if using service account auth.
       required: false
+  responses:
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Forbidden:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
   schemas:
+    ErrorResponse:
+      title: ErrorResponse
+      description: Standard error response
+      type: object
+      properties:
+        error:
+          type: string
+          description: Details about the error that occurred
+        status:
+          type: string
+          enum:
+            - error
     EvaluateFlagsRequest:
       title: EvaluateFlagsRequest
       description: Request body for feature flag evaluation

--- a/openapi/feature-flags.openapi.yaml
+++ b/openapi/feature-flags.openapi.yaml
@@ -11,7 +11,20 @@ info:
     url: https://opensource.org/licenses/MIT
   version: 1.0.0
 servers:
-  - $ref: ./common/feature-flags-api.yaml#/server
+  - url: https://{regionAndDomain}.com
+    description: Mixpanel's feature flags API server.
+    variables:
+      regionAndDomain:
+        default: api.mixpanel
+        enum:
+          - api.mixpanel
+          - api-eu.mixpanel
+          - api-in.mixpanel
+        description: |
+          The server location to be used:
+            * `api.mixpanel` - The default (US) servers used for most projects
+            * `api-eu.mixpanel` - EU servers if you are enrolled in EU Data Residency
+            * `api-in.mixpanel` - India servers if you are enrolled in India Data Residency
 tags:
   - name: Get Variant Assignments
     description: Evaluate feature flags for a specific user
@@ -46,11 +59,47 @@ paths:
               schema:
                 $ref: '#/components/schemas/EvaluateFlagsResponse'
         '400':
-          $ref: ./common/responses.yaml#/400BadRequest
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Details about the error that occurred
+                  status:
+                    type: string
+                    enum:
+                      - error
         '401':
-          $ref: ./common/responses.yaml#/401Unauthorized
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Details about the error that occurred
+                  status:
+                    type: string
+                    enum:
+                      - error
         '403':
-          $ref: ./common/responses.yaml#/403Forbidden
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Details about the error that occurred
+                  status:
+                    type: string
+                    enum:
+                      - error
   /flags/definitions:
     get:
       operationId: get-flag-definitions
@@ -72,12 +121,47 @@ paths:
               schema:
                 $ref: '#/components/schemas/FlagDefinitionsResponse'
         '401':
-          $ref: ./common/responses.yaml#/401Unauthorized
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Details about the error that occurred
+                  status:
+                    type: string
+                    enum:
+                      - error
         '403':
-          $ref: ./common/responses.yaml#/403Forbidden
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Details about the error that occurred
+                  status:
+                    type: string
+                    enum:
+                      - error
 components:
   securitySchemes:
-    $ref: ./common/securitySchemes.yaml
+    ServiceAccount:
+      type: http
+      scheme: basic
+      description: Service Account
+    ProjectSecret:
+      type: http
+      scheme: basic
+      description: Project Secret
+    OAuthToken:
+      type: http
+      scheme: bearer
+      description: OAuth Token
   parameters:
     ProjectToken:
       name: token

--- a/reference/get-flag-definitions-3.mdx
+++ b/reference/get-flag-definitions-3.mdx
@@ -1,4 +1,0 @@
----
-openapi: /openapi/feature-flags.openapi.yaml GET /flags/definitions
-title: Get Feature Flag Definitions
----

--- a/reference/get-flag-definitions.mdx
+++ b/reference/get-flag-definitions.mdx
@@ -1,4 +1,5 @@
 ---
+openapi: /openapi/feature-flags.openapi.yaml GET /flags/definitions
 title: Get Flag Definitions
 ---
 This endpoint returns the flag definitions for all enabled feature flags within a Mixpanel project.

--- a/reference/get-variant-assignments-3.mdx
+++ b/reference/get-variant-assignments-3.mdx
@@ -1,4 +1,0 @@
----
-openapi: /openapi/feature-flags.openapi.yaml GET /flags
-title: Evaluate Feature Flags (GET)
----

--- a/reference/get-variant-assignments.mdx
+++ b/reference/get-variant-assignments.mdx
@@ -1,6 +1,7 @@
 ---
+openapi: /openapi/feature-flags.openapi.yaml GET /flags
 title: Get Variant Assignments
 ---
-This endpoint returns the variant assignments for enabled flags within a Mixpanel project
+This endpoint returns the variant assignments for enabled flags within a Mixpanel project.
 
 This endpoint returns a map from all feature flags that are provisioned within a Mixpanel project to the variant that the current user context is assigned to.


### PR DESCRIPTION
Fix the Feature Flags API reference pages, which rendered empty because the OpenAPI spec referenced `./common/*.yaml` files that were never committed to this repo (regressed in 37fa45e).

- Inline the `servers`, `securitySchemes`, and 400/401/403 response definitions into `feature-flags.openapi.yaml`, matching the resolved form of the legacy `openapi/src/common` partials and every other spec in this repo.
- Collapse the prose-only nav "root" pages and the duplicate `-3` endpoint pages into a single page per endpoint, so `/reference/get-flag-definitions` and `/reference/get-variant-assignments` show both the description and the API reference.
- Remove the `-3` endpoint pages (a Mintlify migration artifact that never existed in docs-legacy); those URLs will 404 by design rather than being preserved via redirects.

Linear link: https://linear.app/mixpanel/issue/TOF-323/

# Test / Rollout plan
- After deploy, open https://docs.mixpanel.com/reference/get-flag-definitions and https://docs.mixpanel.com/reference/get-variant-assignments — each should show the endpoint description plus the full API reference (parameters, auth, responses, and the "try it" panel).
- Locally: run `mintlify dev` at the repo root and verify the two Feature Flags API pages render; `mintlify validate` passes in strict mode.
- Rollback: revert this PR.
