### PR TITLE
SR docs: note custom retention must be configured in UI

### DIFF
--- a/docs/session-replay.mdx
+++ b/docs/session-replay.mdx
@@ -77,7 +77,7 @@ For example, you can sample 1% of all sessions globally, but capture 100% of SDK
 ## Entry Points
 
 <Note>
-By default, replays are stored for 30 days after the time of ingestion. Once a replay is expired, there is no way to view that replay. Enterprise plan customers with the paid session replay add-on can customize this retention period between 7 days and 360 days. For more information, reach out to your Account Manager or our sales team.
+By default, replays are stored for 30 days after the time of ingestion. Once a replay is expired, there is no way to view that replay. Enterprise plan customers with the paid session replay add-on can customize this retention period between 7 days and 360 days. For more information, reach out to your Account Manager or our sales team. Note that a custom retention period does not apply automatically once purchased: after the add-on is provisioned, an organization owner or admin must set the retention period in the project's session replay settings.
 </Note>
 
 Session Replay is particularly valuable for understanding user frustration and identifying problematic user experiences. To find relevant replays, you can focus on interesting users (power users, purchases), interesting trends (KPIs spikes or dips), or replays where certain events or sentiment signals (like [dead clicks](/docs/tracking-methods/autocapture#dead-clicks)/[rage clicks](/docs/tracking-methods/autocapture#rage-clicks)) occur.
@@ -295,7 +295,7 @@ On our mobile SDKs (iOS, Android, and React Native), you control capture with a 
 
 #### How long are replays stored?
 
-By default, replays are stored for 30 days after the time of ingestion. Once a replay is expired, there is no way to view that replay. Enterprise plan customers with the paid session replay add-on can customize this retention period between 7 days and 360 days. For more information, reach out to your Account Manager or our sales team.
+By default, replays are stored for 30 days after the time of ingestion. Once a replay is expired, there is no way to view that replay. Enterprise plan customers with the paid session replay add-on can customize this retention period between 7 days and 360 days. For more information, reach out to your Account Manager or our sales team. Note that a custom retention period does not apply automatically once purchased: after the add-on is provisioned, an organization owner or admin must set the retention period in the project's session replay settings.
 
 #### Why does it say the player failed to load?
 


### PR DESCRIPTION
Adds a one-line note that a custom SR retention period doesn't apply automatically: after provisioning, an owner/admin must set it in the UI. Per Slack thread with Ellen Lebow and Dhaval. Touches the legally-protected FAQ block, so flagging for PM/Legal review before merge.