### PR TITLE
Add redirects for 194 legacy /hc help-center articles

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3985,7 +3985,7 @@
     },
     {
       "source": "/hc/en-us/articles/115004499323*",
-      "destination": "/docs/data-structure/property-reference"
+      "destination": "/docs/"
     },
     {
       "source": "/hc/en-us/articles/115004499383*",
@@ -4041,7 +4041,7 @@
     },
     {
       "source": "/hc/en-us/articles/115004507486*",
-      "destination": "/docs/tracking-methods/sdks/javascript"
+      "destination": "/docs/tracking-methods/sdks/javascript#hosted-subdomains"
     },
     {
       "source": "/hc/en-us/articles/115004511006*",
@@ -4053,11 +4053,11 @@
     },
     {
       "source": "/hc/en-us/articles/115004511126*",
-      "destination": "/docs/reports/apps"
+      "destination": "/docs/"
     },
     {
       "source": "/hc/en-us/articles/115004511206*",
-      "destination": "/docs/data-structure/property-reference"
+      "destination": "/docs/cohort-sync/integrations/salesforce-marketing-cloud"
     },
     {
       "source": "/hc/en-us/articles/115004511226*",
@@ -4105,7 +4105,7 @@
     },
     {
       "source": "/hc/en-us/articles/115004551623*",
-      "destination": "/docs/tracking-methods/data-inspector"
+      "destination": "/docs/tracking-best-practices/debugging#debugging-with-events"
     },
     {
       "source": "/hc/en-us/articles/115004551663*",
@@ -4177,7 +4177,7 @@
     },
     {
       "source": "/hc/en-us/articles/115004563123*",
-      "destination": "/docs/reports"
+      "destination": "/docs/"
     },
     {
       "source": "/hc/en-us/articles/115004563223*",
@@ -4325,15 +4325,15 @@
     },
     {
       "source": "/hc/en-us/articles/115004582646*",
-      "destination": "/docs/reports"
+      "destination": "/docs/"
     },
     {
       "source": "/hc/en-us/articles/115004582706*",
-      "destination": "/docs/reports/insights"
+      "destination": "/docs/"
     },
     {
       "source": "/hc/en-us/articles/115004582746*",
-      "destination": "/docs/boards"
+      "destination": "/docs/"
     },
     {
       "source": "/hc/en-us/articles/115004598183*",
@@ -4433,11 +4433,11 @@
     },
     {
       "source": "/hc/en-us/articles/115004615486*",
-      "destination": "/docs/experiments"
+      "destination": "/docs/"
     },
     {
       "source": "/hc/en-us/articles/115004615566*",
-      "destination": "/docs/tracking-methods/autocapture"
+      "destination": "/docs/"
     },
     {
       "source": "/hc/en-us/articles/115004615626*",
@@ -4489,7 +4489,7 @@
     },
     {
       "source": "/hc/en-us/articles/115004617306*",
-      "destination": "/docs/experiments"
+      "destination": "/docs/"
     },
     {
       "source": "/hc/en-us/articles/115004617386*",
@@ -4605,7 +4605,7 @@
     },
     {
       "source": "/hc/en-us/articles/115004695303*",
-      "destination": "/docs/export-methods"
+      "destination": "/docs/"
     },
     {
       "source": "/hc/en-us/articles/115004702823*",

--- a/docs.json
+++ b/docs.json
@@ -3950,6 +3950,782 @@
     {
       "source": "/docs/features/spark",
       "destination": "/docs/mixpanel-agent"
+    },
+    {
+      "source": "/hc/en-us/articles/115004490463*",
+      "destination": "/docs/orgs-and-projects/managing-projects"
+    },
+    {
+      "source": "/hc/en-us/articles/115004490883*",
+      "destination": "/docs/pricing"
+    },
+    {
+      "source": "/hc/en-us/articles/115004493723*",
+      "destination": "/docs/tracking-best-practices/developer-environments#send-data-to-multiple-projects"
+    },
+    {
+      "source": "/hc/en-us/articles/115004494043*",
+      "destination": "/docs/orgs-and-projects/roles-and-permissions"
+    },
+    {
+      "source": "/hc/en-us/articles/115004494843*",
+      "destination": "/docs/access-security"
+    },
+    {
+      "source": "/hc/en-us/articles/115004496863*",
+      "destination": "/docs/tracking-methods/id-management"
+    },
+    {
+      "source": "/hc/en-us/articles/115004499163*",
+      "destination": "/docs/tracking-methods/id-management"
+    },
+    {
+      "source": "/hc/en-us/articles/115004499223*",
+      "destination": "/docs/tracking-methods/sdks/javascript"
+    },
+    {
+      "source": "/hc/en-us/articles/115004499323*",
+      "destination": "/docs/data-structure/property-reference"
+    },
+    {
+      "source": "/hc/en-us/articles/115004499383*",
+      "destination": "/docs/features/sessions"
+    },
+    {
+      "source": "/hc/en-us/articles/115004499423*",
+      "destination": "/docs/tracking-best-practices/debugging"
+    },
+    {
+      "source": "/hc/en-us/articles/115004499443*",
+      "destination": "/docs/tracking-best-practices/geolocation"
+    },
+    {
+      "source": "/hc/en-us/articles/115004499483*",
+      "destination": "/docs/tracking-best-practices/debugging"
+    },
+    {
+      "source": "/hc/en-us/articles/115004499503*",
+      "destination": "/docs/tracking-methods/data-inspector"
+    },
+    {
+      "source": "/hc/en-us/articles/115004499523*",
+      "destination": "/docs/tracking-best-practices/debugging"
+    },
+    {
+      "source": "/hc/en-us/articles/115004501646*",
+      "destination": "/docs/pricing"
+    },
+    {
+      "source": "/hc/en-us/articles/115004501866*",
+      "destination": "/docs/pricing"
+    },
+    {
+      "source": "/hc/en-us/articles/115004502326*",
+      "destination": "/docs/pricing"
+    },
+    {
+      "source": "/hc/en-us/articles/115004502386*",
+      "destination": "/docs/pricing#view-events-usage"
+    },
+    {
+      "source": "/hc/en-us/articles/115004505546*",
+      "destination": "/docs/orgs-and-projects/roles-and-permissions#project-roles"
+    },
+    {
+      "source": "/hc/en-us/articles/115004506346*",
+      "destination": "/docs/tracking-methods/sdks/javascript"
+    },
+    {
+      "source": "/hc/en-us/articles/115004506386*",
+      "destination": "/docs/tracking-methods/sdks/javascript"
+    },
+    {
+      "source": "/hc/en-us/articles/115004507486*",
+      "destination": "/docs/tracking-methods/sdks/javascript"
+    },
+    {
+      "source": "/hc/en-us/articles/115004511006*",
+      "destination": "/docs/tracking-methods/sdks/javascript"
+    },
+    {
+      "source": "/hc/en-us/articles/115004511106*",
+      "destination": "/docs/tracking-best-practices/debugging"
+    },
+    {
+      "source": "/hc/en-us/articles/115004511126*",
+      "destination": "/docs/reports/apps"
+    },
+    {
+      "source": "/hc/en-us/articles/115004511206*",
+      "destination": "/docs/data-structure/property-reference"
+    },
+    {
+      "source": "/hc/en-us/articles/115004511226*",
+      "destination": "/docs/tracking-best-practices/geolocation"
+    },
+    {
+      "source": "/hc/en-us/articles/115004519306*",
+      "destination": "/docs/quickstart/install-mixpanel"
+    },
+    {
+      "source": "/hc/en-us/articles/115004519426*",
+      "destination": "/docs/tracking-best-practices/tracking-plan"
+    },
+    {
+      "source": "/hc/en-us/articles/115004519846*",
+      "destination": "/docs/tracking-best-practices/tracking-plan"
+    },
+    {
+      "source": "/hc/en-us/articles/115004545603*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004545783*",
+      "destination": "/docs/tracking-methods/sdks"
+    },
+    {
+      "source": "/hc/en-us/articles/115004546823*",
+      "destination": "/docs/tracking-methods/sdks/javascript"
+    },
+    {
+      "source": "/hc/en-us/articles/115004546903*",
+      "destination": "/docs/reports/retention"
+    },
+    {
+      "source": "/hc/en-us/articles/115004547023*",
+      "destination": "/docs/data-structure/property-reference/data-type"
+    },
+    {
+      "source": "/hc/en-us/articles/115004551563*",
+      "destination": "/docs/features/revenue-analytics"
+    },
+    {
+      "source": "/hc/en-us/articles/115004551603*",
+      "destination": "/docs/reports/funnels"
+    },
+    {
+      "source": "/hc/en-us/articles/115004551623*",
+      "destination": "/docs/tracking-methods/data-inspector"
+    },
+    {
+      "source": "/hc/en-us/articles/115004551663*",
+      "destination": "/docs/reports/funnels"
+    },
+    {
+      "source": "/hc/en-us/articles/115004551743*",
+      "destination": "/docs/reports/apps/jql"
+    },
+    {
+      "source": "/hc/en-us/articles/115004552703*",
+      "destination": "/docs/reports"
+    },
+    {
+      "source": "/hc/en-us/articles/115004552803*",
+      "destination": "/docs/experiments"
+    },
+    {
+      "source": "/hc/en-us/articles/115004553843*",
+      "destination": "/docs/experiments"
+    },
+    {
+      "source": "/hc/en-us/articles/115004553863*",
+      "destination": "/docs/data-structure/user-profiles"
+    },
+    {
+      "source": "/hc/en-us/articles/115004553923*",
+      "destination": "/docs/features/revenue-analytics"
+    },
+    {
+      "source": "/hc/en-us/articles/115004554003*",
+      "destination": "/docs/reports/retention"
+    },
+    {
+      "source": "/hc/en-us/articles/115004554023*",
+      "destination": "/docs/reports/funnels"
+    },
+    {
+      "source": "/hc/en-us/articles/115004560746*",
+      "destination": "/docs/migration/google-analytics"
+    },
+    {
+      "source": "/hc/en-us/articles/115004560766*",
+      "destination": "/docs/what-to-track"
+    },
+    {
+      "source": "/hc/en-us/articles/115004561806*",
+      "destination": "/docs/quickstart/install-mixpanel"
+    },
+    {
+      "source": "/hc/en-us/articles/115004561826*",
+      "destination": "/docs/tracking-methods/integrations/google-tag-manager"
+    },
+    {
+      "source": "/hc/en-us/articles/115004562503*",
+      "destination": "/docs/data-structure/property-reference/default-properties"
+    },
+    {
+      "source": "/hc/en-us/articles/115004562563*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004562703*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115004562783*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115004563123*",
+      "destination": "/docs/reports"
+    },
+    {
+      "source": "/hc/en-us/articles/115004563223*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115004563263*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115004564286*",
+      "destination": "/docs/data-structure/group-analytics"
+    },
+    {
+      "source": "/hc/en-us/articles/115004564486*",
+      "destination": "/docs/features/alerts"
+    },
+    {
+      "source": "/hc/en-us/articles/115004565046*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115004565926*",
+      "destination": "/docs/tracking-best-practices/debugging"
+    },
+    {
+      "source": "/hc/en-us/articles/115004565986*",
+      "destination": "/docs/features/custom-buckets"
+    },
+    {
+      "source": "/hc/en-us/articles/115004566066*",
+      "destination": "/docs/reports/retention"
+    },
+    {
+      "source": "/hc/en-us/articles/115004566106*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115004567006*",
+      "destination": "/docs/reports/retention"
+    },
+    {
+      "source": "/hc/en-us/articles/115004567026*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004567363*",
+      "destination": "/docs/boards"
+    },
+    {
+      "source": "/hc/en-us/articles/115004567826*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115004567846*",
+      "destination": "/docs/reports/retention"
+    },
+    {
+      "source": "/hc/en-us/articles/115004567906*",
+      "destination": "/docs/tracking-best-practices/traffic-attribution"
+    },
+    {
+      "source": "/hc/en-us/articles/115004567946*",
+      "destination": "/docs/tracking-best-practices/bot-traffic"
+    },
+    {
+      "source": "/hc/en-us/articles/115004567966*",
+      "destination": "/docs/tracking-best-practices/bot-traffic"
+    },
+    {
+      "source": "/hc/en-us/articles/115004568026*",
+      "destination": "/docs/features/annotations"
+    },
+    {
+      "source": "/hc/en-us/articles/115004568086*",
+      "destination": "/docs/tracking-methods/autocapture"
+    },
+    {
+      "source": "/hc/en-us/articles/115004568106*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115004568543*",
+      "destination": "/docs/reports/apps/signal"
+    },
+    {
+      "source": "/hc/en-us/articles/115004568583*",
+      "destination": "/docs/reports/apps/signal"
+    },
+    {
+      "source": "/hc/en-us/articles/115004568603*",
+      "destination": "/docs/reports/apps/signal"
+    },
+    {
+      "source": "/hc/en-us/articles/115004568743*",
+      "destination": "/docs/reports/retention"
+    },
+    {
+      "source": "/hc/en-us/articles/115004568823*",
+      "destination": "/docs/reports/apps/signal"
+    },
+    {
+      "source": "/hc/en-us/articles/115004569503*",
+      "destination": "/docs/data-governance/lexicon"
+    },
+    {
+      "source": "/hc/en-us/articles/115004575586*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115004575866*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115004575886*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115004580746*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004580826*",
+      "destination": "/docs/reports/apps/signal"
+    },
+    {
+      "source": "/hc/en-us/articles/115004580906*",
+      "destination": "/docs/reports/apps/signal"
+    },
+    {
+      "source": "/hc/en-us/articles/115004582086*",
+      "destination": "/docs/reports/apps/signal"
+    },
+    {
+      "source": "/hc/en-us/articles/115004582126*",
+      "destination": "/docs/reports/apps/signal"
+    },
+    {
+      "source": "/hc/en-us/articles/115004582186*",
+      "destination": "/docs/boards"
+    },
+    {
+      "source": "/hc/en-us/articles/115004582446*",
+      "destination": "/docs/reports/apps/signal"
+    },
+    {
+      "source": "/hc/en-us/articles/115004582646*",
+      "destination": "/docs/reports"
+    },
+    {
+      "source": "/hc/en-us/articles/115004582706*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115004582746*",
+      "destination": "/docs/boards"
+    },
+    {
+      "source": "/hc/en-us/articles/115004598183*",
+      "destination": "/docs/tracking-methods/autocapture"
+    },
+    {
+      "source": "/hc/en-us/articles/115004598283*",
+      "destination": "/docs/tracking-methods/autocapture"
+    },
+    {
+      "source": "/hc/en-us/articles/115004600303*",
+      "destination": "/docs/tracking-methods/autocapture"
+    },
+    {
+      "source": "/hc/en-us/articles/115004600443*",
+      "destination": "/docs/tracking-methods/autocapture"
+    },
+    {
+      "source": "/hc/en-us/articles/115004600463*",
+      "destination": "/docs/tracking-methods/autocapture"
+    },
+    {
+      "source": "/hc/en-us/articles/115004600543*",
+      "destination": "/docs/tracking-methods/autocapture"
+    },
+    {
+      "source": "/hc/en-us/articles/115004600583*",
+      "destination": "/docs/tracking-methods/sdks/android"
+    },
+    {
+      "source": "/hc/en-us/articles/115004600623*",
+      "destination": "/docs/tracking-methods/sdks/ios"
+    },
+    {
+      "source": "/hc/en-us/articles/115004600783*",
+      "destination": "/docs/experiments"
+    },
+    {
+      "source": "/hc/en-us/articles/115004601066*",
+      "destination": "/docs/features/alerts"
+    },
+    {
+      "source": "/hc/en-us/articles/115004601166*",
+      "destination": "/docs/features/alerts"
+    },
+    {
+      "source": "/hc/en-us/articles/115004601443*",
+      "destination": "/docs/tracking-methods/sdks/javascript"
+    },
+    {
+      "source": "/hc/en-us/articles/115004601463*",
+      "destination": "/docs/tracking-methods/sdks/unity"
+    },
+    {
+      "source": "/hc/en-us/articles/115004601483*",
+      "destination": "/docs/tracking-methods/sdks/android"
+    },
+    {
+      "source": "/hc/en-us/articles/115004601523*",
+      "destination": "/docs/data-structure/property-reference/default-properties"
+    },
+    {
+      "source": "/hc/en-us/articles/115004601543*",
+      "destination": "/docs/tracking-methods/sdks"
+    },
+    {
+      "source": "/hc/en-us/articles/115004601563*",
+      "destination": "/docs/data-structure/property-reference"
+    },
+    {
+      "source": "/hc/en-us/articles/115004602143*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004602603*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004602683*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004602703*",
+      "destination": "/docs/data-structure/property-reference/reserved-properties"
+    },
+    {
+      "source": "/hc/en-us/articles/115004613366*",
+      "destination": "/docs/tracking-methods/autocapture"
+    },
+    {
+      "source": "/hc/en-us/articles/115004613466*",
+      "destination": "/docs/tracking-methods/autocapture"
+    },
+    {
+      "source": "/hc/en-us/articles/115004613606*",
+      "destination": "/docs/tracking-methods/autocapture"
+    },
+    {
+      "source": "/hc/en-us/articles/115004615486*",
+      "destination": "/docs/experiments"
+    },
+    {
+      "source": "/hc/en-us/articles/115004615566*",
+      "destination": "/docs/tracking-methods/autocapture"
+    },
+    {
+      "source": "/hc/en-us/articles/115004615626*",
+      "destination": "/docs/tracking-methods/autocapture"
+    },
+    {
+      "source": "/hc/en-us/articles/115004615646*",
+      "destination": "/docs/tracking-methods/autocapture"
+    },
+    {
+      "source": "/hc/en-us/articles/115004615706*",
+      "destination": "/docs/data-structure/property-reference"
+    },
+    {
+      "source": "/hc/en-us/articles/115004615726*",
+      "destination": "/docs/data-structure/user-profiles"
+    },
+    {
+      "source": "/hc/en-us/articles/115004615766*",
+      "destination": "/docs/data-structure/property-reference/data-type"
+    },
+    {
+      "source": "/hc/en-us/articles/115004615786*",
+      "destination": "/docs/tracking-methods/sdks/javascript"
+    },
+    {
+      "source": "/hc/en-us/articles/115004615826*",
+      "destination": "/docs/tracking-methods/sdks/javascript"
+    },
+    {
+      "source": "/hc/en-us/articles/115004616366*",
+      "destination": "/docs/features/revenue-analytics"
+    },
+    {
+      "source": "/hc/en-us/articles/115004616386*",
+      "destination": "/docs/tracking-methods/sdks"
+    },
+    {
+      "source": "/hc/en-us/articles/115004616426*",
+      "destination": "/docs/tracking-methods/sdks/android"
+    },
+    {
+      "source": "/hc/en-us/articles/115004616466*",
+      "destination": "/docs/data-structure/property-reference/properties"
+    },
+    {
+      "source": "/hc/en-us/articles/115004617246*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004617306*",
+      "destination": "/docs/experiments"
+    },
+    {
+      "source": "/hc/en-us/articles/115004617386*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004617426*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004617486*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004617506*",
+      "destination": "/docs/data-structure/user-profiles#faq"
+    },
+    {
+      "source": "/hc/en-us/articles/115004617526*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004617566*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004670543*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004670563*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004670603*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004670703*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004670743*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004670763*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004686363*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004686443*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004686503*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004686543*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004687563*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004687583*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004687743*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004688423*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004688623*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004690006*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004690046*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004690066*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004690086*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004690106*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004690126*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004690166*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004695303*",
+      "destination": "/docs/export-methods"
+    },
+    {
+      "source": "/hc/en-us/articles/115004702823*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004706666*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004706906*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004706966*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004707726*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004707786*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004707946*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115004708066*",
+      "destination": "/docs/features/sessions"
+    },
+    {
+      "source": "/hc/en-us/articles/115004714446*",
+      "destination": "/docs/pricing"
+    },
+    {
+      "source": "/hc/en-us/articles/115004714506*",
+      "destination": "/docs/cohort-sync/integrations/salesforce-marketing-cloud"
+    },
+    {
+      "source": "/hc/en-us/articles/115005061226*",
+      "destination": "/docs/export-methods"
+    },
+    {
+      "source": "/hc/en-us/articles/115005061286*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115005593506*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115005635306*",
+      "destination": "/docs/cohort-sync/integrations/salesforce-marketing-cloud"
+    },
+    {
+      "source": "/hc/en-us/articles/115005641306*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115005665706*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115005694643*",
+      "destination": "/docs/cohort-sync/integrations/marketo"
+    },
+    {
+      "source": "/hc/en-us/articles/115005694663*",
+      "destination": "/docs/cohort-sync/integrations/airship"
+    },
+    {
+      "source": "/hc/en-us/articles/115005697363*",
+      "destination": "/docs/tracking-methods/sdks/javascript"
+    },
+    {
+      "source": "/hc/en-us/articles/115005700166*",
+      "destination": "/docs/cohort-sync/integrations/marketo"
+    },
+    {
+      "source": "/hc/en-us/articles/115005700186*",
+      "destination": "/docs/cohort-sync/integrations/airship"
+    },
+    {
+      "source": "/hc/en-us/articles/115005702243*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115005702623*",
+      "destination": "/docs/users/cohorts"
+    },
+    {
+      "source": "/hc/en-us/articles/115005707803*",
+      "destination": "/docs/reports/retention"
+    },
+    {
+      "source": "/hc/en-us/articles/115005708166*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115005714386*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115005714426*",
+      "destination": "/docs/reports/funnels/funnels-overview"
+    },
+    {
+      "source": "/hc/en-us/articles/115005714446*",
+      "destination": "/docs/reports/insights"
+    },
+    {
+      "source": "/hc/en-us/articles/115005717546*",
+      "destination": "/docs"
+    },
+    {
+      "source": "/hc/en-us/articles/115005736163*",
+      "destination": "/docs/reports/funnels"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The analytics repo's nginx `legacy-redirects.conf` is being updated (branch `tiffany-nginx-help`) to redirect old `/help/questions/articles/*` URLs to `docs.mixpanel.com/hc/en-us/articles/<id>` instead of `help.mixpanel.com`.

Cross-referencing that change against this repo's `docs.json`, **194 of the referenced `/hc/en-us/articles/<id>` paths had no matching redirect** here, so they would 404 on the docs site. This PR adds a `/hc/en-us/articles/<id>* -> /docs/...` redirect for each of those 194 articles.

- Redirects before: 663 → after: **857**
- Every destination was validated against an existing `.mdx` page in this repo (0 broken targets).
- Destinations were mapped **best-effort** to the closest existing docs page using the article's topic and the existing `/hc` redirects as a guide.

## Confidence

| Confidence | Count | Notes |
|---|---|---|
| high | 51 | Clear topical match |
| medium | 71 | Reasonable match, section-level |
| low | 72 | Weak/no equivalent page — please review |

Of the 72 low-confidence entries, **46 fall back to `/docs`** — mostly the legacy Messages/notifications product (push, in-app, email, SMS, A/B test designer) which has no modern docs equivalent.

<details>
<summary>Low-confidence redirects to review (72)</summary>

| source | destination |
|---|---|
| `/hc/en-us/articles/115004499323*` | `/docs/data-structure/property-reference` |
| `/hc/en-us/articles/115004507486*` | `/docs/tracking-methods/sdks/javascript` |
| `/hc/en-us/articles/115004511126*` | `/docs/reports/apps` |
| `/hc/en-us/articles/115004511206*` | `/docs/data-structure/property-reference` |
| `/hc/en-us/articles/115004519306*` | `/docs/quickstart/install-mixpanel` |
| `/hc/en-us/articles/115004545603*` | `/docs` |
| `/hc/en-us/articles/115004551623*` | `/docs/tracking-methods/data-inspector` |
| `/hc/en-us/articles/115004552703*` | `/docs/reports` |
| `/hc/en-us/articles/115004562563*` | `/docs` |
| `/hc/en-us/articles/115004563123*` | `/docs/reports` |
| `/hc/en-us/articles/115004563223*` | `/docs/reports/insights` |
| `/hc/en-us/articles/115004567026*` | `/docs` |
| `/hc/en-us/articles/115004580746*` | `/docs` |
| `/hc/en-us/articles/115004582646*` | `/docs/reports` |
| `/hc/en-us/articles/115004582706*` | `/docs/reports/insights` |
| `/hc/en-us/articles/115004582746*` | `/docs/boards` |
| `/hc/en-us/articles/115004600463*` | `/docs/tracking-methods/autocapture` |
| `/hc/en-us/articles/115004600543*` | `/docs/tracking-methods/autocapture` |
| `/hc/en-us/articles/115004600783*` | `/docs/experiments` |
| `/hc/en-us/articles/115004601483*` | `/docs/tracking-methods/sdks/android` |
| `/hc/en-us/articles/115004602143*` | `/docs` |
| `/hc/en-us/articles/115004602603*` | `/docs` |
| `/hc/en-us/articles/115004602683*` | `/docs` |
| `/hc/en-us/articles/115004615486*` | `/docs/experiments` |
| `/hc/en-us/articles/115004615646*` | `/docs/tracking-methods/autocapture` |
| `/hc/en-us/articles/115004615786*` | `/docs/tracking-methods/sdks/javascript` |
| `/hc/en-us/articles/115004615826*` | `/docs/tracking-methods/sdks/javascript` |
| `/hc/en-us/articles/115004616386*` | `/docs/tracking-methods/sdks` |
| `/hc/en-us/articles/115004617246*` | `/docs` |
| `/hc/en-us/articles/115004617306*` | `/docs/experiments` |
| `/hc/en-us/articles/115004617386*` | `/docs` |
| `/hc/en-us/articles/115004617426*` | `/docs` |
| `/hc/en-us/articles/115004617486*` | `/docs` |
| `/hc/en-us/articles/115004617526*` | `/docs` |
| `/hc/en-us/articles/115004617566*` | `/docs` |
| `/hc/en-us/articles/115004670543*` | `/docs` |
| `/hc/en-us/articles/115004670563*` | `/docs` |
| `/hc/en-us/articles/115004670603*` | `/docs` |
| `/hc/en-us/articles/115004670703*` | `/docs` |
| `/hc/en-us/articles/115004670743*` | `/docs` |
| `/hc/en-us/articles/115004670763*` | `/docs` |
| `/hc/en-us/articles/115004686363*` | `/docs` |
| `/hc/en-us/articles/115004686443*` | `/docs` |
| `/hc/en-us/articles/115004686503*` | `/docs` |
| `/hc/en-us/articles/115004686543*` | `/docs` |
| `/hc/en-us/articles/115004687563*` | `/docs` |
| `/hc/en-us/articles/115004687583*` | `/docs` |
| `/hc/en-us/articles/115004687743*` | `/docs` |
| `/hc/en-us/articles/115004688423*` | `/docs` |
| `/hc/en-us/articles/115004688623*` | `/docs` |
| `/hc/en-us/articles/115004690006*` | `/docs` |
| `/hc/en-us/articles/115004690046*` | `/docs` |
| `/hc/en-us/articles/115004690066*` | `/docs` |
| `/hc/en-us/articles/115004690086*` | `/docs` |
| `/hc/en-us/articles/115004690106*` | `/docs` |
| `/hc/en-us/articles/115004690126*` | `/docs` |
| `/hc/en-us/articles/115004690166*` | `/docs` |
| `/hc/en-us/articles/115004695303*` | `/docs/export-methods` |
| `/hc/en-us/articles/115004702823*` | `/docs` |
| `/hc/en-us/articles/115004706666*` | `/docs` |
| `/hc/en-us/articles/115004706906*` | `/docs` |
| `/hc/en-us/articles/115004706966*` | `/docs` |
| `/hc/en-us/articles/115004707726*` | `/docs` |
| `/hc/en-us/articles/115004707786*` | `/docs` |
| `/hc/en-us/articles/115004707946*` | `/docs` |
| `/hc/en-us/articles/115004708066*` | `/docs/features/sessions` |
| `/hc/en-us/articles/115004714506*` | `/docs/cohort-sync/integrations/salesforce-marketing-cloud` |
| `/hc/en-us/articles/115005593506*` | `/docs` |
| `/hc/en-us/articles/115005635306*` | `/docs/cohort-sync/integrations/salesforce-marketing-cloud` |
| `/hc/en-us/articles/115005641306*` | `/docs` |
| `/hc/en-us/articles/115005665706*` | `/docs` |
| `/hc/en-us/articles/115005717546*` | `/docs` |

</details>

## How to review

- High/medium entries are safe to merge as-is.
- For low-confidence entries, Tiffany already went through them to compare the names of the pages and put them through our docs search to find the one that makes the most sense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Here's a map of the id to nginx url that it generated from my [legacy redirects in nginx](https://github.com/mixpanel/analytics/blob/master/kube/lib/webapp/nginx/legacy-redirects.conf):

| # | Article ID | nginx slug | docs redirect | confidence |
|---|---|---|---|---|
| 1 | 115004490463 | how-do-i-reset-my-project-key-secret-or-token | /docs/orgs-and-projects/managing-projects | high |
| 2 | 115004490883 | i-paid-for-an-event-plan-so-why-are-my-projects-still-locked | /docs/pricing | medium |
| 3 | 115004493723 | can-i-send-data-from-one-website-to-two-different-mixpanel-projects | /docs/tracking-best-practices/developer-environments#send-data-to-multiple-projects | high |
| 4 | 115004494043 | how-do-i-add-or-remove-people-from-a-project | /docs/orgs-and-projects/roles-and-permissions | high |
| 5 | 115004494843 | how-do-i-report-security-vulnerabilities | /docs/access-security | medium |
| 6 | 115004496863 | why-do-some-distinct-ids-in-my-live-view-appear-as-emails-and-others-as-a-hash-of-random-letters-and-numbers | /docs/tracking-methods/id-management | medium |
| 7 | 115004499163 | how-should-i-use-alias-and-identify-for-my-existing-users-who-have-already-signed-up | /docs/tracking-methods/id-management | high |
| 8 | 115004499223 | how-to-prevent-getdistinctid-and-getproperty-from-returning-undefined | /docs/tracking-methods/sdks/javascript | medium |
| 9 | 115004499323 | what-are-the-current-size-limits-for-data-sets | /docs/data-structure/property-reference | low |
| 10 | 115004499383 | how-can-i-change-the-session-length-requirements-for-the-app-session-event | /docs/features/sessions | high |
| 11 | 115004499423 | why-do-i-see-no-name-null-or-nan-values | /docs/tracking-best-practices/debugging | medium |
| 12 | 115004499443 | why-are-city-and-region-sometimes-not-provided-as-properties-even-though-country-is | /docs/tracking-best-practices/geolocation | high |
| 13 | 115004499483 | why-isnt-my-import-working | /docs/tracking-best-practices/debugging | medium |
| 14 | 115004499503 | why-are-my-events-out-of-order-in-live-view-or-a-users-activity-feed | /docs/tracking-methods/data-inspector | medium |
| 15 | 115004499523 | i-hit-the-server-but-my-data-is-not-showing | /docs/tracking-best-practices/debugging | high |
| 16 | 115004501646 | mixpanel-new-people-pricing-faq | /docs/pricing | high |
| 17 | 115004501866 | how-can-i-get-a-receipt | /docs/pricing | medium |
| 18 | 115004502326 | how-does-the-free-plan-work | /docs/pricing | high |
| 19 | 115004502386 | how-many-data-points-do-i-have | /docs/pricing#view-events-usage | high |
| 20 | 115004505546 | what-are-the-different-roles-available-to-mixpanel-project-members | /docs/orgs-and-projects/roles-and-permissions#project-roles | high |
| 21 | 115004506346 | how-can-i-send-data-to-mixpanel-over-https-instead-of-http-using-the-javascript-library | /docs/tracking-methods/sdks/javascript | medium |
| 22 | 115004506386 | how-can-i-force-the-mixpanel-cookie-to-be-secure | /docs/tracking-methods/sdks/javascript | medium |
| 23 | 115004507486 | mixpanel-and-herokuappcom-subdomains-and-other-common-top-level-domains | /docs/tracking-methods/sdks/javascript | low |
| 24 | 115004511006 | how-do-i-track-users-across-different-domains | /docs/tracking-methods/sdks/javascript | medium |
| 25 | 115004511106 | why-am-i-getting-the-message-mixpanel-error-implementation-error-please-contact-supportmixpanelcom | /docs/tracking-best-practices/debugging | medium |
| 26 | 115004511126 | why-would-a-predict-model-not-be-accepted | /docs/reports/apps | low |
| 27 | 115004511206 | what-are-the-property-limits-on-imports-from-custom-salesforce-fields | /docs/data-structure/property-reference | low |
| 28 | 115004511226 | are-there-certain-countries-from-which-mixpanel-cant-collect-data | /docs/tracking-best-practices/geolocation | medium |
| 29 | 115004519306 | added-snippet | /docs/quickstart/install-mixpanel | low |
| 30 | 115004519426 | what-happens-if-i-change-an-event-name | /docs/tracking-best-practices/tracking-plan | medium |
| 31 | 115004519846 | how-do-i-create-a-tracking-plan | /docs/tracking-best-practices/tracking-plan | high |
| 32 | 115004545603 | webinar-resource-page | /docs | low |
| 33 | 115004545783 | what-languages-does-mixpanel-work-with | /docs/tracking-methods/sdks | medium |
| 34 | 115004546823 | can-i-host-the-js-file-myself | /docs/tracking-methods/sdks/javascript | medium |
| 35 | 115004546903 | how-are-segmented-retention-reports-calculated | /docs/reports/retention | high |
| 36 | 115004547023 | how-does-mixpanel-treat-numbers | /docs/data-structure/property-reference/data-type | high |
| 37 | 115004551563 | why-is-lifetime-value-in-revenue-decreasing-over-time | /docs/features/revenue-analytics | medium |
| 38 | 115004551603 | how-can-i-look-at-users-in-a-funnel-who-did-event-a-or-event-b | /docs/reports/funnels | medium |
| 39 | 115004551623 | why-cant-i-choose-a-certain-time-period-to-look-at-in-live-view | /docs/tracking-methods/data-inspector | low |
| 40 | 115004551663 | what-does-other-represent-when-segmenting-a-funnel | /docs/reports/funnels | high |
| 41 | 115004551743 | can-i-use-custom-events-in-jql | /docs/reports/apps/jql | high |
| 42 | 115004552703 | why-do-the-dates-switch-and-show-only-two-or-three-months-of-data-at-a-time-in-certain-reports | /docs/reports | low |
| 43 | 115004552803 | how-can-i-tell-if-a-user-was-in-the-original-or-variant-group-of-my-ab-test | /docs/experiments | high |
| 44 | 115004553843 | can-i-run-multiple-ab-tests-at-once-and-can-users-be-in-multiple-ab-tests | /docs/experiments | high |
| 45 | 115004553863 | how-can-i-add-a-picture-to-a-persons-profile-in-explore | /docs/data-structure/user-profiles | medium |
| 46 | 115004553923 | how-do-i-import-revenue-data | /docs/features/revenue-analytics | medium |
| 47 | 115004554003 | why-cant-i-filter-the-anything-event-in-retention | /docs/reports/retention | high |
| 48 | 115004554023 | can-i-create-optional-steps-in-my-funnel-report | /docs/reports/funnels | high |
| 49 | 115004560746 | can-i-use-mixpanel-and-google-analytics-at-the-same-time | /docs/migration/google-analytics | medium |
| 50 | 115004560766 | how-can-i-use-mixpanel-to-achieve-my-business-goals | /docs/what-to-track | medium |
| 51 | 115004561806 | how-can-i-implement-mixpanel-on-my-chrome-extension | /docs/quickstart/install-mixpanel | medium |
| 52 | 115004561826 | can-i-implement-mixpanel-using-google-tag-manager | /docs/tracking-methods/integrations/google-tag-manager | high |
| 53 | 115004562503 | why-are-iphone-applications-reporting-operating-system-as-either-ios-or-iphone-os | /docs/data-structure/property-reference/default-properties | medium |
| 54 | 115004562563 | how-can-i-see-a-preview-of-what-my-users-on-older-versions-of-the-mixpanel-sdks-will-see-for-customized-in_app-notifications | /docs | low |
| 55 | 115004562703 | can-i-save-my-insights-reports | /docs/reports/insights | medium |
| 56 | 115004562783 | -who-has-access-to-insights | /docs/reports/insights | medium |
| 57 | 115004563123 | how-many-reports-can-i-save-in-my-mixpanel-project | /docs/reports | low |
| 58 | 115004563223 | after-i-have-created-and-saved-my-report-how-do-i-build-a-new-one | /docs/reports/insights | low |
| 59 | 115004563263 | what-is-the-difference-between-filter-and-groupby-in-the-insights-report | /docs/reports/insights | medium |
| 60 | 115004564286 | how-do-i-track-users-if-they-are-part-of-multiple-organizations#multi_org_ex | /docs/data-structure/group-analytics | medium |
| 61 | 115004564486 | can-i-set-up-certain-reports-to-be-emailed-to-me-on-a-regular-basis-or-receive-email-alerts-when-certain-events-happen | /docs/features/alerts | high |
| 62 | 115004565046 | how-are-unique-vs-total-users-calculated | /docs/reports/insights | medium |
| 63 | 115004565926 | why-are-some-events-or-properties-missing-from-my-dropdowns | /docs/tracking-best-practices/debugging | medium |
| 64 | 115004565986 | how-do-i-view-numeric-properties-in-segmentation-so-that-each-bar-is-a-single-number-not-a-range | /docs/features/custom-buckets | high |
| 65 | 115004566066 | what-does-a-first-time-retention-report-mean-and-how-does-mixpanel-know-that-this-is-the-first-instance-of-the-user-firing-the-event | /docs/reports/retention | medium |
| 66 | 115004566106 | how-do-i-see-dau-and-mau-in-mixpanel | /docs/reports/insights | medium |
| 67 | 115004567006 | what-does-anything-include-in-retention-reports | /docs/reports/retention | medium |
| 68 | 115004567026 | how-can-i-determine-which-variant-messageid-a-user-received-from-my-notifications-campaign | /docs | low |
| 69 | 115004567363 | what-do-growth-marketing-product-project-dashboard-and-my-dashboard-mean-in-dashboards | /docs/boards | medium |
| 70 | 115004567826 | how-can-i-get-the-formulas-report-to-display-my-ratio-as-a-percent-instead-of-a-decimal | /docs/reports/insights | medium |
| 71 | 115004567846 | can-users-be-included-in-multiple-cohorts-in-retention-reports | /docs/reports/retention | medium |
| 72 | 115004567906 | how-do-i-analyze-organic-users-vs-paid-users- | /docs/tracking-best-practices/traffic-attribution | medium |
| 73 | 115004567946 | how-do-i-exclude-bot-activity-from-my-data | /docs/tracking-best-practices/bot-traffic | high |
| 74 | 115004567966 | how-do-i-exclude-bot-activity-from-my-android-data | /docs/tracking-best-practices/bot-traffic | high |
| 75 | 115004568026 | can-i-delete-annotations-for-us-holidays-or-add-annotations-for-my-countrys-holidays | /docs/features/annotations | high |
| 76 | 115004568086 | what-is-the-mppageview-event-and-can-i-see-the-associated-data | /docs/tracking-methods/autocapture | medium |
| 77 | 115004568106 | how-are-rolling-averages-calculated | /docs/reports/insights | medium |
| 78 | 115004568543 | when-should-i-use-signal | /docs/reports/apps/signal | high |
| 79 | 115004568583 | what-do-top-events-include-in-signal-can-i-exclude-specific-events-from-top-events | /docs/reports/apps/signal | high |
| 80 | 115004568603 | what-is-the-difference-between-new-users-and-any-users-in-signal | /docs/reports/apps/signal | high |
| 81 | 115004568743 | how-are-retention-cards-in-dashboards-calculated | /docs/reports/retention | medium |
| 82 | 115004568823 | how-is-retention-defined-in-signal | /docs/reports/apps/signal | high |
| 83 | 115004569503 | what-is-lexicon | /docs/data-governance/lexicon | high |
| 84 | 115004575586 | where-can-i-find-more-information-on-insights | /docs/reports/insights | high |
| 85 | 115004575866 | how-is-insights-different-than-segmentation | /docs/reports/insights | high |
| 86 | 115004575886 | what-kind-of-visualization-tools-are-available-with-insights | /docs/reports/insights | medium |
| 87 | 115004580746 | what-is-predict | /docs | low |
| 88 | 115004580826 | -how-does-signal-display-the-results | /docs/reports/apps/signal | high |
| 89 | 115004580906 | how-does-mixpanel-interpret-the-results-in-signal | /docs/reports/apps/signal | high |
| 90 | 115004582086 | building-a-query-with-signal | /docs/reports/apps/signal | high |
| 91 | 115004582126 | can-i-build-a-query-in-signal-with-a-group-of-events-besides-my-top-events | /docs/reports/apps/signal | high |
| 92 | 115004582186 | how-do-i-add-a-report-to-any-dashboard | /docs/boards | medium |
| 93 | 115004582446 | what-are-the-summary-statistics-in-my-signal-csv-export | /docs/reports/apps/signal | high |
| 94 | 115004582646 | which-reports-can-i-sync-from-web-to-the-mobile-app | /docs/reports | low |
| 95 | 115004582706 | how-can-i-view-segmented-data-in-the-mobile-app | /docs/reports/insights | low |
| 96 | 115004582746 | how-can-i-view-my-web-dashboards-using-the-mixpanel-mobile-app | /docs/boards | low |
| 97 | 115004598183 | what-options-are-available-for-codeless-tracking | /docs/tracking-methods/autocapture | medium |
| 98 | 115004598283 | what-custom-css-selectors-are-supported-in-the-autotrack-point_and_click-editor | /docs/tracking-methods/autocapture | medium |
| 99 | 115004600303 | how-do-i-change-or-remove-autotrack-events | /docs/tracking-methods/autocapture | medium |
| 100 | 115004600443 | how-do-i-get-started-with-codeless-mobile-event-tracking | /docs/tracking-methods/autocapture | medium |
| 101 | 115004600463 | ive-enabled-autotrack-but-the-point-and-click-editor-wont-load-on-my-site | /docs/tracking-methods/autocapture | low |
| 102 | 115004600543 | is-default-common-event-tracking-available-for-the-web-or-any-other-libraries-besides-mobile | /docs/tracking-methods/autocapture | low |
| 103 | 115004600583 | how-can-i-use-multiple-install-trackers-with-the-android-library | /docs/tracking-methods/sdks/android | medium |
| 104 | 115004600623 | does-mixpanel-support-arc-in-ios | /docs/tracking-methods/sdks/ios | medium |
| 105 | 115004600783 | how-can-i-effectively-ab-test-the-very-first-screen-or-sign_up-flow-of-my-app | /docs/experiments | low |
| 106 | 115004601066 | anomaly-detection-in-mixpanel | /docs/features/alerts | medium |
| 107 | 115004601166 | how-do-i-get-started-using-web-anomalies | /docs/features/alerts | medium |
| 108 | 115004601443 | how-can-i-implement-mixpanel-on-my-angular-app | /docs/tracking-methods/sdks/javascript | medium |
| 109 | 115004601463 | is-webgl-supported-in-the-mixpanel-unity-sdk | /docs/tracking-methods/sdks/unity | high |
| 110 | 115004601483 | how-do-i-track-app-uninstalls-in-mixpanel | /docs/tracking-methods/sdks/android | low |
| 111 | 115004601523 | can-i-choose-not-to-send-mixpanel-default-properties | /docs/data-structure/property-reference/default-properties | high |
| 112 | 115004601543 | can-i-customize-the-interval-at-which-data-gets-flushed-to-mixpanel-on-mobile | /docs/tracking-methods/sdks | medium |
| 113 | 115004601563 | how-do-i-implement-incremental-super-properties-on-mobile | /docs/data-structure/property-reference | medium |
| 114 | 115004602143 | /learn/inapp/? | /docs | low |
| 115 | 115004602603 | authenticating-mixpanel-email-with-dkim | /docs | low |
| 116 | 115004602683 | why-are-users-not-sent-my-notification | /docs | low |
| 117 | 115004602703 | special-or-reserved-properties | /docs/data-structure/property-reference/reserved-properties | high |
| 118 | 115004613366 | what-is-autotrack-and-how-do-i-get-started-using-it | /docs/tracking-methods/autocapture | medium |
| 119 | 115004613466 | why-dont-i-see-my-autotrack-events-in-some-reports-and-places-in-mixpanel | /docs/tracking-methods/autocapture | medium |
| 120 | 115004613606 | how-do-i-customize-autotrack-events-by-adding-elements-and-properties | /docs/tracking-methods/autocapture | medium |
| 121 | 115004615486 | why-is-my-device-showing-a-blank-screen-when-connected-to-the-ab-testing-or-codeless-events-designer- | /docs/experiments | low |
| 122 | 115004615566 | can-i-use-autotrack-on-a-single_page-website | /docs/tracking-methods/autocapture | medium |
| 123 | 115004615626 | autotrack-quick-tips | /docs/tracking-methods/autocapture | medium |
| 124 | 115004615646 | what-if-i-enable-common-mobile-events-but-i-am-already-tracking-some-of-the-default-events | /docs/tracking-methods/autocapture | low |
| 125 | 115004615706 | where-are-super-properties-stored | /docs/data-structure/property-reference | medium |
| 126 | 115004615726 | where-are-people-properties-stored | /docs/data-structure/user-profiles | high |
| 127 | 115004615766 | objective_c-ios-property-dates-types | /docs/data-structure/property-reference/data-type | medium |
| 128 | 115004615786 | how-to-track-with-mixpanel-inside-a-canvas-or-iframe | /docs/tracking-methods/sdks/javascript | low |
| 129 | 115004615826 | how-do-i-track-an-event-when-a-document-or-image-renders | /docs/tracking-methods/sdks/javascript | low |
| 130 | 115004616366 | how-can-i-track-transactions-in-multiple-currencies | /docs/features/revenue-analytics | medium |
| 131 | 115004616386 | how-can-i-use-mixpanel-with-windows-phone-apps | /docs/tracking-methods/sdks | low |
| 132 | 115004616426 | how-can-i-reduce-the-size-of-the-mixpanel-android-sdk | /docs/tracking-methods/sdks/android | medium |
| 133 | 115004616466 | are-there-any-limits-on-how-many-properties-i-can-send-to-mixpanel | /docs/data-structure/property-reference/properties | medium |
| 134 | 115004617246 | why-is-my-in_app-notification-blank | /docs | low |
| 135 | 115004617306 | how-can-i-disable-production-devices-from-connecting-to-the-ab-test-designer | /docs/experiments | low |
| 136 | 115004617386 | can-a-user-receive-a-notification-more-than-once | /docs | low |
| 137 | 115004617426 | why-arent-my-push-notifications-sending | /docs | low |
| 138 | 115004617486 | why-are-ios-device-push-tokens-being-removed-when-we-try-to-send-push-notifications | /docs | low |
| 139 | 115004617506 | why-are-there-fewer-people-profiles-in-explore-than-unique-user-counts-in-segmentation | /docs/data-structure/user-profiles#faq | medium |
| 140 | 115004617526 | how-do-i-customize-my-email-unsubscribe-link | /docs | low |
| 141 | 115004617566 | why-is-my-gcm-api-key-invalid | /docs | low |
| 142 | 115004670543 | can-i-revert-to-a-previous-version-of-a-notification | /docs | low |
| 143 | 115004670563 | can-i-send-notifications-via-mixpanel-using-an-api-instead-of-via-the-ui | /docs | low |
| 144 | 115004670603 | how-do-i-manually-unsubscribe-a-single-user-or-many-users-in-bulk | /docs | low |
| 145 | 115004670703 | how-do-i-send-more-sms-than-the-mixpanel-1000month-limit- | /docs | low |
| 146 | 115004670743 | why-is-the-number-of-users-targeted-different-between-using-explore-and-notifications-even-though-im-using-the-same-filter | /docs | low |
| 147 | 115004670763 | how-can-i-control-when-my-mobile-in_app-notification-shows- | /docs | low |
| 148 | 115004686363 | can-i-use-event-properties-for-in_app-notifications-surveys-and-ab-testing | /docs | low |
| 149 | 115004686443 | how-do-i-send-a-push-notification-that-contains-both-an-emoji-and-a-deep-link | /docs | low |
| 150 | 115004686503 | how-do-i-deep-link-a-user-to-a-specific-activity-from-an-android-push-notification | /docs | low |
| 151 | 115004686543 | how-can-i-stop-or-modify-my-notification-campaigns-while-im-blocked-from-accessing-my-account | /docs | low |
| 152 | 115004687563 | how-do-notification-analytics-work | /docs | low |
| 153 | 115004687583 | how-do-i-insert-an-external-web-link-into-an-ios-push-notification | /docs | low |
| 154 | 115004687743 | how-can-i-manage-the-twilio-sms-subscription-settings | /docs | low |
| 155 | 115004688423 | what-is-a-smart-notification | /docs | low |
| 156 | 115004688623 | what-happens-when-i-reprioritize-a-smart-notification-if-it-is-already-in-the-process-of-sending | /docs | low |
| 157 | 115004690006 | how-do-i-send-a-notification-based-on-whether-the-user-opened-a-previous-notification | /docs | low |
| 158 | 115004690046 | how-do-i-see-a-list-of-people-who-have-unsubscribed-from-receiving-my-notifications | /docs | low |
| 159 | 115004690066 | how-do-i-manage-unsubscribe-requests-if-im-using-multiple-notification-platforms | /docs | low |
| 160 | 115004690086 | why-do-i-see-pending-verification-on-my-email-campaign | /docs | low |
| 161 | 115004690106 | how-can-i-track-email-notification-open-rate | /docs | low |
| 162 | 115004690126 | how-do-i-programmatically-disable-in_app-notifications-or-restrict-them-to-show-only-on-certain-pages-or-screens | /docs | low |
| 163 | 115004690166 | how-does-mixpanel-manage-push-tokens-when-they-are-invalid-or-when-the-app-has-been-uninstalled | /docs | low |
| 164 | 115004695303 | how-do-i-connect-mixpanel-with-microsoft-power-bi | /docs/export-methods | low |
| 165 | 115004702823 | /help/reference/sending-a-message/? | /docs | low |
| 166 | 115004706666 | why-does-a-users-activity-feed-say-they-received-a-push-notification-multiple-times | /docs | low |
| 167 | 115004706906 | does-mixpanel-integrate-with-firebase-cloud-messaging-fcm | /docs | low |
| 168 | 115004706966 | why-are-my-in_app-notifications-dismissing-unexpectedly-after-one-second | /docs | low |
| 169 | 115004707726 | how-do-i-create-smart-notifications | /docs | low |
| 170 | 115004707786 | what-happens-when-i-move-a-notification-from-smart-to-regular-notifications-or-vice-versa | /docs | low |
| 171 | 115004707946 | how-are-smart-notification-analytics-calculated | /docs | low |
| 172 | 115004708066 | how-can-i-measure-bounce-rate-with-mixpanel | /docs/features/sessions | low |
| 173 | 115004714446 | is-there-a-limit-to-the-number-of-events-i-can-send-to-mixpanel | /docs/pricing | medium |
| 174 | 115004714506 | how-do-i-integrate-mixpanel-into-salesforce | /docs/cohort-sync/integrations/salesforce-marketing-cloud | low |
| 175 | 115005061226 | how-can-i-export-my-raw-data-from-mixpanel | /docs/export-methods | high |
| 176 | 115005061286 | how-do-i-build-segmentation-expressions | /docs/reports/insights | medium |
| 177 | 115005593506 | how-to-get-started-with-zapier | /docs | low |
| 178 | 115005635306 | how-can-i-customize-the-properties-that-are-imported-from-my-salesforce-dataset | /docs/cohort-sync/integrations/salesforce-marketing-cloud | low |
| 179 | 115005641306 | how-does-the-mixpanel-zendesk-app-match-users-between-mixpanel-and-zendesk | /docs | low |
| 180 | 115005665706 | what-mixpanel-triggers-and-actions-are-supported-with-zapier | /docs | low |
| 181 | 115005694643 | where-do-i-find-my-credentials-for-marketo | /docs/cohort-sync/integrations/marketo | high |
| 182 | 115005694663 | where-do-i-find-my-credentials-for-urban-airship | /docs/cohort-sync/integrations/airship | high |
| 183 | 115005697363 | upgrading-the-javascript-library | /docs/tracking-methods/sdks/javascript | high |
| 184 | 115005700166 | how-do-i-set-up-my-marketo-integration | /docs/cohort-sync/integrations/marketo | high |
| 185 | 115005700186 | how-do-i-set-up-my-urban-airship-integration | /docs/cohort-sync/integrations/airship | high |
| 186 | 115005702243 | what-is-happening-to-the-insight-report | /docs/reports/insights | high |
| 187 | 115005702623 | which-reports-can-use-cohorts | /docs/users/cohorts | medium |
| 188 | 115005707803 | retention-overview-video | /docs/reports/retention | high |
| 189 | 115005708166 | what-do-i-need-to-know-about-automated-segmentation | /docs/reports/insights | medium |
| 190 | 115005714386 | how-can-i-analyze-users-who-did-not-do-an-event | /docs/reports/insights | medium |
| 191 | 115005714426 | funnels-overview-video | /docs/reports/funnels/funnels-overview | high |
| 192 | 115005714446 | segmentation-overview-video | /docs/reports/insights | medium |
| 193 | 115005717546 | what-caused-my-email-message-to-bounce | /docs | low |
| 194 | 115005736163 | how-can-i-make-a-copy-of-an-existing-funnel | /docs/reports/funnels | medium |

**Notes on shared IDs** (one redirect covers multiple old nginx paths; one representative slug shown):
- #178 `115005635306` also serves: `how-can-i-use-mixpanel-datasets`, `how-can-i-use-salesforce-data-sets`, `how-do-i-enable-data-connectors-in-mixpanel`
- #188 `115005707803` also serves: `/learn/retention/`
- #192 `115005714446` also serves: `/learn/segmentation/`
