### PR TITLE
Fix retention page 500 error - remove invalid backslash

### DIFF
--- a/docs/reports/retention.mdx
+++ b/docs/reports/retention.mdx
@@ -278,7 +278,8 @@ Above said, the general expectation is that product use-cases which focus on use
 
 You can save the Funnel Behavior you built and reuse it in other reports. This can be helpful when there is a sequence of events that you frequently analyze (such as sign-up flow), or if you want to analyze your Funnels Behavior alongside other metrics in an Insights report.
 
-Select the "..." button in the top right corner of the metric, then click "Save Behavior".\
+Select the "..." button in the top right corner of the metric, then click "Save Behavior".
+
 Learn more about [Saved Metrics and Behaviors](/docs/features/saved-metrics-and-behaviors).
 
 ### Frequency View


### PR DESCRIPTION
## Problem
The retention report page (https://docs.mixpanel.com/docs/reports/retention) is returning Error 500.

## Root Cause
Line 281 has a trailing backslash (`\`) that's causing Mintlify's parser to fail:
```
Select the "..." button in the top right corner of the metric, then click "Save Behavior".```

This triggers a URI malformed error in `decodeURIComponent`:
```
RIError: URI malformed
    at decodeURIComponent (<anonymous>)
```

## Fix
Removed the invalid backslash and added proper paragraph spacing:
```markdown
Select the "..." button in the top right corner of the metric, then click "Save Behavior".

Learn more about [Saved Metrics and Behaviors](/docs/features/saved-metrics-and-behaviors).
```

## Testing
- ✅ File parses without errors locally
- ✅ No other backslashes causing issues
- ✅ Preview should work once deployed

Fixes the 500 error that's been occurring since commit e48a3917 (July 21).