### PR TITLE
Add Autocapture screen view/leave docs for mobile SDKs

### DIFF
--- a/docs/tracking-methods/sdks/android.mdx
+++ b/docs/tracking-methods/sdks/android.mdx
@@ -639,6 +639,56 @@ A few commonly used group methods are highlighted below:
   </Tab>
 </Tabs>
 
+## Autocapture
+
+Modern mobile apps use a variety of UI frameworks and architectural patterns — single-Activity apps with Jetpack Compose, multi-Activity apps with Fragments, or a mix of both. Each defines and transitions between "screens" differently, making it impractical for the SDK to automatically detect screen boundaries across all setups. Instead, Mixpanel provides explicit methods on the `autocapture` object that you hook into your app's navigation, giving you full control over what counts as a screen and when transitions happen.
+
+### Screen View & Screen Leave
+
+Track screen navigations using `trackScreenView` and `trackScreenLeave`. These methods fire the following events:
+
+| Method | Mixpanel Event |
+| --- | --- |
+| `trackScreenView()` | `$mp_page_view` |
+| `trackScreenLeave()` | `$mp_page_leave` |
+
+Both events automatically include `current_page_title` (the screen name) and `$mp_autocapture: true`.
+
+<Tabs>
+  <Tab title="Jetpack Compose">
+    Observe the navigation controller's current route inside a `LaunchedEffect`:
+
+    ```kotlin
+    val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
+    var previousRoute by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(currentRoute) {
+        currentRoute?.let { route ->
+            val mixpanel = MixpanelAPI.getInstance(context, "YOUR_TOKEN", true)
+
+            previousRoute?.let { mixpanel.autocapture.trackScreenLeave(it) }
+            mixpanel.autocapture.trackScreenView(route)
+
+            previousRoute = route
+        }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+#### Passing Custom Properties
+
+Both methods accept an optional `JSONObject` parameter for custom properties. For example, forwarding UTM params from a deep link:
+
+```kotlin
+val utmProps = JSONObject().apply {
+    put("utm_source", uri.getQueryParameter("utm_source"))
+    put("utm_medium", uri.getQueryParameter("utm_medium"))
+    put("utm_campaign", uri.getQueryParameter("utm_campaign"))
+}
+mixpanel.autocapture.trackScreenView("PromoScreen", utmProps)
+```
+
 ## Session Replay
 
 Install the [Session Replay SDK for Android](/docs/tracking-methods/sdks/android/android-replay) to record replay data. Learn more about [Session Replay](/docs/session-replay) and [implementing Session Replay on Android](/docs/tracking-methods/sdks/android/android-replay).

--- a/docs/tracking-methods/sdks/android.mdx
+++ b/docs/tracking-methods/sdks/android.mdx
@@ -641,9 +641,11 @@ A few commonly used group methods are highlighted below:
 
 ## Autocapture
 
-Modern mobile apps use a variety of UI frameworks and architectural patterns — single-Activity apps with Jetpack Compose, multi-Activity apps with Fragments, or a mix of both. Each defines and transitions between "screens" differently, making it impractical for the SDK to automatically detect screen boundaries across all setups. Instead, Mixpanel provides explicit methods on the `autocapture` object that you hook into your app's navigation, giving you full control over what counts as a screen and when transitions happen.
+The Mixpanel Android SDK provides methods on the `autocapture` object to help you track common user interactions with minimal instrumentation. These methods fire standardized events that are recognized by the Mixpanel platform.
 
 ### Screen View & Screen Leave
+
+Modern mobile apps use a variety of UI frameworks and architectural patterns — single-Activity apps with Jetpack Compose, multi-Activity apps with Fragments, or a mix of both. Each defines and transitions between "screens" differently, making it impractical for the SDK to automatically detect screen boundaries across all setups. Instead, you hook `trackScreenView` and `trackScreenLeave` into your app's navigation, giving you full control over what counts as a screen and when transitions happen.
 
 Track screen navigations using `trackScreenView` and `trackScreenLeave`. These methods fire the following events:
 

--- a/docs/tracking-methods/sdks/flutter.mdx
+++ b/docs/tracking-methods/sdks/flutter.mdx
@@ -489,9 +489,11 @@ A few commonly used group methods are highlighted below:
 
 ## Autocapture
 
-Flutter apps use widget-based routing with `Navigator`, `GoRouter`, or other packages, each handling screen transitions differently. This makes it impractical for the SDK to automatically detect screen boundaries. Instead, Mixpanel provides explicit methods on the `autocapture` object that you hook into your app's navigation, giving you full control over what counts as a screen and when transitions happen.
+The Mixpanel Flutter SDK provides methods on the `autocapture` object to help you track common user interactions with minimal instrumentation. These methods fire standardized events that are recognized by the Mixpanel platform.
 
 ### Screen View & Screen Leave
+
+Flutter apps use widget-based routing with `Navigator`, `GoRouter`, or other packages, each handling screen transitions differently. This makes it impractical for the SDK to automatically detect screen boundaries. Instead, you hook `trackScreenView` and `trackScreenLeave` into your app's navigation, giving you full control over what counts as a screen and when transitions happen.
 
 Track screen navigations using `trackScreenView` and `trackScreenLeave`. These methods fire the following events:
 

--- a/docs/tracking-methods/sdks/flutter.mdx
+++ b/docs/tracking-methods/sdks/flutter.mdx
@@ -538,6 +538,29 @@ Both events automatically include `current_page_title` (the screen name) and `$m
           }
         });
       }
+
+      @override
+      void didReplace({Route? newRoute, Route? oldRoute}) {
+        super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+        _mixpanelFuture.then((mp) async {
+          if (oldRoute?.settings.name != null) {
+            await mp.autocapture.trackScreenLeave(oldRoute!.settings.name!);
+          }
+          if (newRoute?.settings.name != null) {
+            await mp.autocapture.trackScreenView(newRoute!.settings.name!);
+          }
+        });
+      }
+
+      @override
+      void didRemove(Route route, Route? previousRoute) {
+        super.didRemove(route, previousRoute);
+        _mixpanelFuture.then((mp) async {
+          if (route.settings.name != null) {
+            await mp.autocapture.trackScreenLeave(route.settings.name!);
+          }
+        });
+      }
     }
     ```
 

--- a/docs/tracking-methods/sdks/flutter.mdx
+++ b/docs/tracking-methods/sdks/flutter.mdx
@@ -487,6 +487,80 @@ A few commonly used group methods are highlighted below:
   </Tab>
 </Tabs>
 
+## Autocapture
+
+Flutter apps use widget-based routing with `Navigator`, `GoRouter`, or other packages, each handling screen transitions differently. This makes it impractical for the SDK to automatically detect screen boundaries. Instead, Mixpanel provides explicit methods on the `autocapture` object that you hook into your app's navigation, giving you full control over what counts as a screen and when transitions happen.
+
+### Screen View & Screen Leave
+
+Track screen navigations using `trackScreenView` and `trackScreenLeave`. These methods fire the following events:
+
+| Method | Mixpanel Event |
+| --- | --- |
+| `trackScreenView()` | `$mp_page_view` |
+| `trackScreenLeave()` | `$mp_page_leave` |
+
+Both events automatically include `current_page_title` (the screen name) and `$mp_autocapture: true`.
+
+<Tabs>
+  <Tab title="Navigator">
+    Create a `NavigatorObserver` and attach it to your `MaterialApp`:
+
+    ```dart
+    class MixpanelNavigatorObserver extends NavigatorObserver {
+      final Future<Mixpanel> _mixpanelFuture;
+      MixpanelNavigatorObserver(this._mixpanelFuture);
+
+      @override
+      void didPush(Route route, Route? previousRoute) {
+        super.didPush(route, previousRoute);
+        _mixpanelFuture.then((mp) async {
+          if (previousRoute?.settings.name != null) {
+            await mp.autocapture.trackScreenLeave(previousRoute!.settings.name!);
+          }
+          if (route.settings.name != null) {
+            await mp.autocapture.trackScreenView(route.settings.name!);
+          }
+        });
+      }
+
+      @override
+      void didPop(Route route, Route? previousRoute) {
+        super.didPop(route, previousRoute);
+        _mixpanelFuture.then((mp) async {
+          if (route.settings.name != null) {
+            await mp.autocapture.trackScreenLeave(route.settings.name!);
+          }
+          if (previousRoute?.settings.name != null) {
+            await mp.autocapture.trackScreenView(previousRoute!.settings.name!);
+          }
+        });
+      }
+    }
+    ```
+
+    ```dart
+    MaterialApp(
+      navigatorObservers: [MixpanelNavigatorObserver(mixpanelFuture)],
+      // ...
+    );
+    ```
+  </Tab>
+</Tabs>
+
+#### Passing Custom Properties
+
+Both methods accept an optional `properties` parameter. For example, forwarding UTM params from a deep link:
+
+```dart
+final utmProps = {
+  "utm_source": uri.queryParameters["utm_source"],
+  "utm_medium": uri.queryParameters["utm_medium"],
+  "utm_campaign": uri.queryParameters["utm_campaign"],
+};
+await mixpanel.autocapture.trackScreenView("PromoScreen", properties: utmProps);
+```
+
 ## Debug Mode
 
 To enable debug mode, call [`.setLoggingEnabled()`](https://mixpanel.github.io/mixpanel-flutter/mixpanel_flutter/Mixpanel/setLoggingEnabled.html) with `true`.

--- a/docs/tracking-methods/sdks/react-native.mdx
+++ b/docs/tracking-methods/sdks/react-native.mdx
@@ -596,6 +596,65 @@ const variantValue = await mixpanel.flags.getVariantValue('my-feature-flag', 'co
 
 See the [Feature Flags (React Native)](/docs/tracking-methods/sdks/react-native/react-native-flags) guide for the full API, including runtime targeting, persistence policies, sync evaluation, and context updates.
 
+## Autocapture
+
+React Native apps use JavaScript-driven navigators like React Navigation or Expo Router, each handling screen transitions differently. This makes it impractical for the SDK to automatically detect screen boundaries. Instead, Mixpanel provides explicit methods on the `autocapture` object that you hook into your app's navigation, giving you full control over what counts as a screen and when transitions happen.
+
+### Screen View & Screen Leave
+
+Track screen navigations using `trackScreenView` and `trackScreenLeave`. These methods fire the following events:
+
+| Method | Mixpanel Event |
+| --- | --- |
+| `trackScreenView()` | `$mp_page_view` |
+| `trackScreenLeave()` | `$mp_page_leave` |
+
+Both events automatically include `current_page_title` (the screen name) and `$mp_autocapture: true`.
+
+<Tabs>
+  <Tab title="React Navigation">
+    Use `onReady` and `onStateChange` on the `NavigationContainer` to track screen transitions:
+
+    ```tsx
+    const navigationRef = useNavigationContainerRef();
+    const previousRouteRef = useRef<string | undefined>();
+
+    <NavigationContainer
+      ref={navigationRef}
+      onReady={() => {
+        const route = navigationRef.getCurrentRoute()?.name;
+        previousRouteRef.current = route;
+        if (route) mixpanel.autocapture.trackScreenView(route);
+      }}
+      onStateChange={() => {
+        const current = navigationRef.getCurrentRoute()?.name;
+        const previous = previousRouteRef.current;
+
+        if (current !== previous) {
+          if (previous) mixpanel.autocapture.trackScreenLeave(previous);
+          if (current) mixpanel.autocapture.trackScreenView(current);
+        }
+        previousRouteRef.current = current;
+      }}
+    />
+    ```
+  </Tab>
+</Tabs>
+
+#### Passing Custom Properties
+
+Both methods accept an optional properties object. For example, forwarding UTM params from a deep link:
+
+```tsx
+const url = new URL(deepLinkUrl);
+const utmProps = {
+  utm_source: url.searchParams.get("utm_source"),
+  utm_medium: url.searchParams.get("utm_medium"),
+  utm_campaign: url.searchParams.get("utm_campaign"),
+};
+mixpanel.autocapture.trackScreenView("PromoScreen", utmProps);
+```
+
 ## Session Replay
 
 Session Replay records the mobile UI of your React Native app so you can see what your users saw. Recording ships as a separate package, `@mixpanel/react-native-session-replay`, and installs alongside the main `mixpanel-react-native` SDK.

--- a/docs/tracking-methods/sdks/react-native.mdx
+++ b/docs/tracking-methods/sdks/react-native.mdx
@@ -598,9 +598,11 @@ See the [Feature Flags (React Native)](/docs/tracking-methods/sdks/react-native/
 
 ## Autocapture
 
-React Native apps use JavaScript-driven navigators like React Navigation or Expo Router, each handling screen transitions differently. This makes it impractical for the SDK to automatically detect screen boundaries. Instead, Mixpanel provides explicit methods on the `autocapture` object that you hook into your app's navigation, giving you full control over what counts as a screen and when transitions happen.
+The Mixpanel React Native SDK provides methods on the `autocapture` object to help you track common user interactions with minimal instrumentation. These methods fire standardized events that are recognized by the Mixpanel platform.
 
 ### Screen View & Screen Leave
+
+React Native apps use JavaScript-driven navigators like React Navigation or Expo Router, each handling screen transitions differently. This makes it impractical for the SDK to automatically detect screen boundaries. Instead, you hook `trackScreenView` and `trackScreenLeave` into your app's navigation, giving you full control over what counts as a screen and when transitions happen.
 
 Track screen navigations using `trackScreenView` and `trackScreenLeave`. These methods fire the following events:
 

--- a/docs/tracking-methods/sdks/swift.mdx
+++ b/docs/tracking-methods/sdks/swift.mdx
@@ -696,6 +696,86 @@ A few commonly used group methods are highlighted below:
   </Tab>
 </Tabs>
 
+## Autocapture
+
+Modern iOS apps use a variety of UI frameworks — UIKit with view controllers, SwiftUI with `NavigationStack`, or a mix of both. Each defines and transitions between "screens" differently, making it impractical for the SDK to automatically detect screen boundaries across all setups. Instead, Mixpanel provides explicit methods on the `autocapture` object that you hook into your app's navigation, giving you full control over what counts as a screen and when transitions happen.
+
+### Screen View & Screen Leave
+
+Track screen navigations using `trackScreenView` and `trackScreenLeave`. These methods fire the following events:
+
+| Method | Mixpanel Event |
+| --- | --- |
+| `trackScreenView()` | `$mp_page_view` |
+| `trackScreenLeave()` | `$mp_page_leave` |
+
+Both events automatically include `current_page_title` (the screen name) and `$mp_autocapture: true`.
+
+<Tabs>
+  <Tab title="Manual">
+    Call these methods from any view controller or SwiftUI view:
+
+    ```swift
+    Mixpanel.mainInstance().autocapture.trackScreenView(screenName: "HomeScreen")
+    Mixpanel.mainInstance().autocapture.trackScreenLeave(screenName: "HomeScreen")
+    ```
+  </Tab>
+  <Tab title="UIKit (Swizzling)">
+    Swizzle `viewDidAppear` and `viewWillDisappear` once at launch to track every view controller automatically:
+
+    ```swift
+    // In AppDelegate.didFinishLaunchingWithOptions:
+    Mixpanel.initialize(token: "YOUR_TOKEN", trackAutomaticEvents: true)
+    UIViewController.setupAutomaticScreenTracking()
+    ```
+
+    ```swift
+    extension UIViewController {
+        static func setupAutomaticScreenTracking() {
+            swizzle(#selector(viewDidAppear(_:)), with: #selector(mp_viewDidAppear(_:)))
+            swizzle(#selector(viewWillDisappear(_:)), with: #selector(mp_viewWillDisappear(_:)))
+        }
+
+        @objc private func mp_viewDidAppear(_ animated: Bool) {
+            mp_viewDidAppear(animated)
+            let name = String(describing: type(of: self))
+            guard !name.hasPrefix("UI"), !name.hasPrefix("_") else { return }
+            Mixpanel.mainInstance().autocapture.trackScreenView(screenName: name)
+        }
+
+        @objc private func mp_viewWillDisappear(_ animated: Bool) {
+            mp_viewWillDisappear(animated)
+            let name = String(describing: type(of: self))
+            guard !name.hasPrefix("UI"), !name.hasPrefix("_") else { return }
+            Mixpanel.mainInstance().autocapture.trackScreenLeave(screenName: name)
+        }
+
+        private static func swizzle(_ original: Selector, with swizzled: Selector) {
+            guard let m1 = class_getInstanceMethod(UIViewController.self, original),
+                  let m2 = class_getInstanceMethod(UIViewController.self, swizzled)
+            else { return }
+            method_exchangeImplementations(m1, m2)
+        }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+#### Passing Custom Properties
+
+Both methods accept an optional `properties` parameter. For example, forwarding UTM params from a deep link:
+
+```swift
+let utmProps: Properties = [
+    "utm_source": urlComponents.queryItems?["utm_source"] ?? "",
+    "utm_medium": urlComponents.queryItems?["utm_medium"] ?? "",
+    "utm_campaign": urlComponents.queryItems?["utm_campaign"] ?? ""
+]
+Mixpanel.mainInstance().autocapture.trackScreenView(
+    screenName: "PromoScreen", properties: utmProps
+)
+```
+
 ## Session Replay
 
 Install the [Session Replay SDK for Swift](/docs/tracking-methods/sdks/swift/swift-replay) to record replay data. Learn more about [Session Replay](/docs/session-replay) and [implementing Session Replay on iOS](/docs/tracking-methods/sdks/swift/swift-replay).

--- a/docs/tracking-methods/sdks/swift.mdx
+++ b/docs/tracking-methods/sdks/swift.mdx
@@ -768,10 +768,11 @@ Both events automatically include `current_page_title` (the screen name) and `$m
 Both methods accept an optional `properties` parameter. For example, forwarding UTM params from a deep link:
 
 ```swift
+let queryItems = urlComponents.queryItems
 let utmProps: Properties = [
-    "utm_source": urlComponents.queryItems?["utm_source"] ?? "",
-    "utm_medium": urlComponents.queryItems?["utm_medium"] ?? "",
-    "utm_campaign": urlComponents.queryItems?["utm_campaign"] ?? ""
+    "utm_source": queryItems?.first(where: { $0.name == "utm_source" })?.value ?? "",
+    "utm_medium": queryItems?.first(where: { $0.name == "utm_medium" })?.value ?? "",
+    "utm_campaign": queryItems?.first(where: { $0.name == "utm_campaign" })?.value ?? ""
 ]
 Mixpanel.mainInstance().autocapture.trackScreenView(
     screenName: "PromoScreen", properties: utmProps

--- a/docs/tracking-methods/sdks/swift.mdx
+++ b/docs/tracking-methods/sdks/swift.mdx
@@ -698,9 +698,11 @@ A few commonly used group methods are highlighted below:
 
 ## Autocapture
 
-Modern iOS apps use a variety of UI frameworks — UIKit with view controllers, SwiftUI with `NavigationStack`, or a mix of both. Each defines and transitions between "screens" differently, making it impractical for the SDK to automatically detect screen boundaries across all setups. Instead, Mixpanel provides explicit methods on the `autocapture` object that you hook into your app's navigation, giving you full control over what counts as a screen and when transitions happen.
+The Mixpanel Swift SDK provides methods on the `autocapture` object to help you track common user interactions with minimal instrumentation. These methods fire standardized events that are recognized by the Mixpanel platform.
 
 ### Screen View & Screen Leave
+
+Modern iOS apps use a variety of UI frameworks — UIKit with view controllers, SwiftUI with `NavigationStack`, or a mix of both. Each defines and transitions between "screens" differently, making it impractical for the SDK to automatically detect screen boundaries across all setups. Instead, you hook `trackScreenView` and `trackScreenLeave` into your app's navigation, giving you full control over what counts as a screen and when transitions happen.
 
 Track screen navigations using `trackScreenView` and `trackScreenLeave`. These methods fire the following events:
 


### PR DESCRIPTION
## Summary
- Adds `## Autocapture` section with `### Screen View & Screen Leave` to Android, iOS (Swift), Flutter, and React Native SDK docs
- Code examples use `<Tabs>` component for extensibility (e.g. adding Activity/Fragment, SwiftUI, GoRouter, Expo Router examples later)
- Includes `#### Passing Custom Properties` with UTM deep link example
- Section structure supports future autocapture features (click, rage click, dead click) as sibling `###` headings

## Files changed
- `docs/tracking-methods/sdks/android.mdx`
- `docs/tracking-methods/sdks/swift.mdx`
- `docs/tracking-methods/sdks/flutter.mdx`
- `docs/tracking-methods/sdks/react-native.mdx`

## Linear
SDK-139

🤖 Generated with [Claude Code](https://claude.com/claude-code)