### PR TITLE
docs: add Claude Code plugin section to MCP server page

### DIFF
--- a/changelogs.mdx
+++ b/changelogs.mdx
@@ -9,6 +9,23 @@ Get all the latest updates in your inbox.
 
 <SubscribeButtonWithModal />
 
+<Update label="2026-07-29">
+  ## Mixpanel plugin for Claude Code: MCP connection and skills in one install
+
+  Claude Code users can now set up Mixpanel with a single plugin install. The plugin configures the [Mixpanel MCP server](/docs/mcp) connection automatically and adds 11 skills — guided workflows for tracking implementation, metric investigation, dashboard creation, experiments, feature flags, and Lexicon management.
+
+  ```bash
+  claude plugin marketplace add mixpanel/ai-plugins
+  claude plugin install mixpanel-mcp
+  ```
+
+  Regional variants are available for EU (`mixpanel-mcp-eu`) and India (`mixpanel-mcp-in`) data residency. The skills are open source at [github.com/mixpanel/ai-plugins](https://github.com/mixpanel/ai-plugins).
+
+  [Learn more →](/docs/mcp#claude-code-plugin)
+
+  **Note:** Available to all plans. An organization admin must have MCP enabled in **Settings → Org → Overview**.
+</Update>
+
 <Update label="2026-07-28">
   ## AI-Powered Data Governance: merge suggestions for duplicate events and properties
 

--- a/docs/mcp.mdx
+++ b/docs/mcp.mdx
@@ -138,6 +138,10 @@ claude mcp add --transport http mixpanel https://mcp.mixpanel.com/mcp
 
 Then authenticate by running `/mcp` inside Claude Code and completing the Mixpanel OAuth flow in your browser.
 
+<Tip>
+  The [Mixpanel plugin for Claude Code](#claude-code-plugin) sets up this connection automatically and adds skills — guided workflows for tracking implementation, metric investigation, dashboards, and experiments.
+</Tip>
+
 ### ChatGPT
 
 [Add Mixpanel to ChatGPT](https://chatgpt.com/apps/mixpanel/asdk_app_69b2e9aed45c8191b254b207dfcc2bb4) and complete the Mixpanel OAuth flow.
@@ -382,6 +386,45 @@ Or edit `~/.gemini/settings.json` manually and add (use the EU or IN URL if need
 ### Microsoft Copilot (JSON-configured clients)
 
 Any client that supports the MCP JSON config format, including Microsoft Copilot, can connect using the same JSON snippet from the Cursor section above — adding the `headers` object with the [authorization header](#generating-the-authorization-header).
+
+## Claude Code Plugin
+
+The [Mixpanel plugin for Claude Code](https://github.com/mixpanel/ai-plugins) bundles the MCP server connection with a set of skills — guided workflows for the analytics work Mixpanel customers do most. Installing the plugin configures the MCP connection automatically; you authenticate with the Mixpanel OAuth flow the first time Claude uses a Mixpanel tool.
+
+**Add the Mixpanel marketplace**, then install the plugin for your region:
+
+```bash
+claude plugin marketplace add mixpanel/ai-plugins
+
+# US
+claude plugin install mixpanel-mcp
+
+# EU
+claude plugin install mixpanel-mcp-eu
+
+# India
+claude plugin install mixpanel-mcp-in
+```
+
+### Included Skills
+
+Claude invokes skills automatically based on your request, or you can invoke one directly with `/skill-name` (for example, `/deep-research`).
+
+| Skill | What It Does |
+| --- | --- |
+| `analyze-report` | Reads and explains an existing report or chart — what it shows and what's notable |
+| `create-dashboard` | Builds a well-designed dashboard with validated reports, text cards, and narrative layout |
+| `deep-research` | Runs a structured root-cause investigation into why a metric changed |
+| `learn-mcp` | Onboards you to the MCP server through guided, interactive modules |
+| `manage-boards` | Full dashboard lifecycle: create, template, clone, inventory, and clean up boards |
+| `manage-experiment` | Coaches you through experiment design, launch, mid-flight monitoring, and interpretation |
+| `manage-feature-flags` | Creates, rolls out, debugs, and cleans up feature flags |
+| `manage-lexicon` | Audits, scores, enriches, and cleans up Lexicon metadata |
+| `monitor-metrics` | Detects anomalies and drift in a metric and diagnoses root cause |
+| `prepare-ai-readiness` | Sets up business context and Lexicon metadata so Mixpanel's AI assistants understand your data |
+| `tracking-implementation` | Guides an analytics implementation: quick start, full setup, adding tracking, or an audit |
+
+The plugin's skills are open source at [github.com/mixpanel/ai-plugins](https://github.com/mixpanel/ai-plugins). The same [Permissions & Access](#permissions--access) rules apply — MCP must be enabled for your organization, and Claude can only see projects your Mixpanel user can access.
 
 ## Example Queries
 


### PR DESCRIPTION
## What changed

- **New `## Claude Code Plugin` section** on `/docs/mcp` (placed after the Service Accounts section, before Example Queries): what the plugin bundles, marketplace add + regional install commands (`mixpanel-mcp` / `-eu` / `-in`), an 11-skill table, and a pointer back to Permissions & Access
- **`<Tip>` in Connecting with OAuth → Claude Code** linking to the new section, so users setting up MCP manually discover the one-step path
- **Changelog entry** (`2026-07-29`) announcing the plugin — drop this commit's changelogs.mdx hunk if marketing wants different timing; the docs section stands alone

## Why

We're submitting the plugin to [Anthropic's official Claude Code plugin directory](https://github.com/anthropics/claude-plugins-official), and its `homepage` field points at `/docs/mcp` (see mixpanel/ai-plugins#37). Today that page documents the MCP server but never mentions the plugin, so a user clicking through from the directory listing lands on a page that doesn't cover what they just installed.

## Notes

- Skill list matches what's actually in [mixpanel/ai-plugins](https://github.com/mixpanel/ai-plugins/tree/main/plugins/mixpanel-mcp/skills) as of today (11 skills)
- No images added; the changelog entry ships without a hero — add one from brand if this gets announced properly
- Check the Mintlify preview for the anchor `#claude-code-plugin` resolving from the Tip

🤖 Generated with [Claude Code](https://claude.com/claude-code)