### PR TITLE
Add $mp_experiment_name to reserved event properties

### DIFF
--- a/docs/data-structure/property-reference/reserved-properties.mdx
+++ b/docs/data-structure/property-reference/reserved-properties.mdx
@@ -57,3 +57,4 @@ Mixpanel reserves certain property names for special processing or for specific 
 | \$event\_count | Session Event Count | The number of events during a session (i.e. Session Start and Session End). This does not include [Excluded Events](/docs/features/sessions#excluded-events) and [Hidden Events](/docs/data-governance/lexicon#hide-events-and-properties) in Lexicon. See [How Sessions Work](/docs/features/sessions#how-sessions-work). |
 | \$origin\_start | Session Start Event Name | The original event name that triggered Session Start event. See [How Sessions Work](/docs/features/sessions#how-sessions-work). |
 | \$origin\_end | Session End Event Name | The original event name that triggered Session End event. See [How Sessions Work](/docs/features/sessions#how-sessions-work). |
+| \$mp\_experiment\_name | Mp Experiment Name | Internal Mixpanel property used to track the experiment name. |


### PR DESCRIPTION
We added new property for tracking experiment events for billing. Add to docs for visibility that we use this property