### PR TITLE
Dropping Note About Source Merge Events Not Appearing in Existing Reports

### DIFF
--- a/docs/data-governance/lexicon.mdx
+++ b/docs/data-governance/lexicon.mdx
@@ -274,10 +274,6 @@ By merging “Purchase” and “purchase item” into a single event named “P
 Being able to merge events can help streamline your implementation, reduce your costs by eliminating redundant events being sent to Mixpanel, and simplify report analysis because you’re only using optimal events and properties. Do note however that user profile properties cannot be merged at this time.
 
 <Note>
-  After you merge an event into another, it no longer appears in reports or custom events that reference it. Update those reports with the new merged event to maintain accuracy.
-</Note>
-
-<Note>
   [Autocapture](/docs/tracking-methods/autocapture) events cannot be merged. These events are displayed using preset labels such as “\[Auto\] Page View” and “\[Auto\] Element Click”.
 </Note>
 


### PR DESCRIPTION
Removes the callout in the **Merging Events** section of the Lexicon docs:

> After you merge an event into another, it no longer appears in reports or
> custom events that reference it. Update those reports with the new merged
> event to maintain accuracy.

One file changed (`docs/data-governance/lexicon.mdx`), 4 lines deleted. No
other content touched — the adjacent Autocapture callout stays.